### PR TITLE
reactive forms

### DIFF
--- a/src/client/app/heroic/heroes/hero-list.component.ts
+++ b/src/client/app/heroic/heroes/hero-list.component.ts
@@ -46,7 +46,8 @@ import { Subject } from 'rxjs/Subject';
         *ngIf="selectedHero || addingHero"
         [hero]="selectedHero"
         (unselect)="unselect()"
-        (heroChanged)="save($event)">
+        (add)="add($event)"
+        (update)="update($event)">
       </app-hero-detail>
     </div>
   `,
@@ -121,8 +122,16 @@ export class HeroListComponent implements OnDestroy, OnInit {
     this.selectedHero = hero;
   }
 
-  save(arg: { mode: 'add' | 'update'; hero: Hero }) {
-    this.heroDispatchers.save(arg.hero, arg.mode);
+  update(hero: Hero) {
+    this.save('update', hero);
+  }
+
+  add(hero: Hero) {
+    this.save('add', hero);
+  }
+
+  save(mode: 'add' | 'update', hero: Hero) {
+    this.heroDispatchers.save(hero, mode);
   }
 
   unselect() {

--- a/src/client/app/heroic/heroic.module.ts
+++ b/src/client/app/heroic/heroic.module.ts
@@ -1,13 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { HeroicRoutingModule, routedComponents } from './heroic-routing.module';
 import { HeroDetailComponent } from './heroes/hero-detail.component';
 import { VillainDetailComponent } from './villains/villain-detail.component';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, HeroicRoutingModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, HeroicRoutingModule],
   exports: [VillainDetailComponent, HeroDetailComponent, routedComponents],
   declarations: [VillainDetailComponent, HeroDetailComponent, routedComponents]
 })

--- a/src/client/app/heroic/villains/villain-list.component.ts
+++ b/src/client/app/heroic/villains/villain-list.component.ts
@@ -46,7 +46,8 @@ import { Subject } from 'rxjs/Subject';
         *ngIf="selectedVillain || addingVillain"
         [villain]="selectedVillain"
         (unselect)="unselect()"
-        (villainChanged)="save($event)">
+        (add)="add($event)"
+        (update)="update($event)">
       </app-villain-detail>
     </div>
   `,
@@ -121,8 +122,16 @@ export class VillainListComponent implements OnDestroy, OnInit {
     this.selectedVillain = villain;
   }
 
-  save(arg: { mode: 'add' | 'update'; villain: Villain }) {
-    this.villainDispatchers.save(arg.villain, arg.mode);
+  update(villain: Villain) {
+    this.save('update', villain);
+  }
+
+  add(villain: Villain) {
+    this.save('add', villain);
+  }
+
+  save(mode: 'add' | 'update', villain: Villain) {
+    this.villainDispatchers.save(villain, mode);
   }
 
   unselect() {


### PR DESCRIPTION
## Purpose

* resolves problem with AOT warning where we were modifying the immutable state of the detail form entities via ngModel
* we're now using full reactive mode with ngrx and reactiveforms

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* can still update, add, and view hero details
* can still cancel an edit

## Other Information

- `editingHero` is gone now. We had been cloning the hero in the child detail component, so we could edit it and then pass that back up the chain. also, `clone()` is gone.
- added reactive forms
- added a formbuilder with the basic form elements
- the "ah ha" moment is when we see that the detail form is not connected to the state. instead we edit the form and then emit the changes on top of the original state 

