### PR TITLE
Feature: add Entity filters

### DIFF
--- a/src/client/app/core/entity-filters.ts
+++ b/src/client/app/core/entity-filters.ts
@@ -1,0 +1,21 @@
+import { EntityFilters, ENTITY_FILTERS } from '../../ngrx-data';
+
+/** EntityFilter function: match pattern in the name or the saying. */
+function NameOrSayingFilterFn<T>(entities: T[], pattern: string) {
+  pattern = pattern && pattern.trim();
+  if (!pattern) { return entities; }
+  const regEx = new RegExp(pattern, 'i');
+  return entities.filter((e: any) => regEx.test(e.name) || regEx.test(e.saying));
+}
+
+export const NAME_OR_SAYING_FILTER = 'NameOrSaying';
+
+/** Custom application entity filters */
+const entityFilters: EntityFilters = {
+  [NAME_OR_SAYING_FILTER]: { filterFn: NameOrSayingFilterFn },
+  // '': { filterFn: NameOrSayingFilterFn } // replace the default
+}
+
+export const entityFiltersProvider = {
+  provide: ENTITY_FILTERS, multi: true, useValue: entityFilters
+}

--- a/src/client/app/heroes/hero-list/hero-list.component.ts
+++ b/src/client/app/heroes/hero-list/hero-list.component.ts
@@ -57,7 +57,7 @@ export class HeroListComponent implements OnDestroy, OnInit {
     this.filteredHeroes$ = this.heroSelector.filteredEntities$();
     this.heroes$ = this.heroSelector.entities$();
     this.loading$ = this.heroSelector.loading$();
-    this.filter$ = this.heroSelector.filter$();
+    this.filter$ = this.heroSelector.filterPattern$();
 
     this.dataSource$
       .pipe(takeUntil(this.onDestroy), distinctUntilChanged())
@@ -74,8 +74,8 @@ export class HeroListComponent implements OnDestroy, OnInit {
     this.onDestroy.next(true);
   }
 
-  setFilter(value: string) {
-    this.heroDispatcher.setFilter(value);
+  setFilter(pattern: string) {
+    this.heroDispatcher.setFilterPattern(pattern);
     this.clear();
   }
 

--- a/src/client/app/store/entity-store.module.ts
+++ b/src/client/app/store/entity-store.module.ts
@@ -1,16 +1,18 @@
-import { NgModule } from '@angular/core';
-import { StoreModule } from '@ngrx/store';
+import { NgModule, InjectionToken } from '@angular/core';
+import { StoreModule, ActionReducer } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 
 import {
-  EntityCache,
   EntityCollection,
   entityEffects,
   EntityDataServiceConfig,
-  entityReducer,
+  EntityFilterService,
+  ENTITY_REDUCER_TOKEN,
   NgrxDataModule,
   PLURALIZER_NAMES
 } from '../../ngrx-data';
+
+import { entityFiltersProvider, NAME_OR_SAYING_FILTER } from '../core/entity-filters';
 
 const entityDataServiceConfig: EntityDataServiceConfig = {
   api: '/api',
@@ -22,7 +24,8 @@ export function initialState() {
   const empty = new EntityCollection();
   return {
     Hero: empty,
-    Villain: empty
+    // Initialize with a custom filter for Villains
+    Villain: {...empty, filter: {name: NAME_OR_SAYING_FILTER}}
   };
 }
 
@@ -33,11 +36,12 @@ const pluralNames = {
 
 @NgModule({
   imports: [
-    StoreModule.forFeature('entityCache', entityReducer, { initialState }),
+    StoreModule.forFeature('entityCache', ENTITY_REDUCER_TOKEN, { initialState }),
     EffectsModule.forFeature(entityEffects),
     NgrxDataModule
   ],
   providers: [
+    entityFiltersProvider,
     { provide: PLURALIZER_NAMES, useValue: pluralNames },
     { provide: EntityDataServiceConfig, useValue: entityDataServiceConfig }
   ]

--- a/src/client/app/villains/villain-list/villain-list.component.ts
+++ b/src/client/app/villains/villain-list/villain-list.component.ts
@@ -3,6 +3,7 @@ import { FormControl } from '@angular/forms';
 
 import { AppSelectors } from '../../store/app-config';
 import {
+  EntityFilter,
   EntityDispatchers,
   EntityDispatcher,
   EntitySelectors,
@@ -29,7 +30,7 @@ export class VillainListComponent implements OnDestroy, OnInit {
   filteredVillains$: Observable<Villain[]>;
   villains$: Observable<Villain[]>;
   loading$: Observable<boolean>;
-  filter$: Observable<string>;
+  filter$: Observable<EntityFilter>;
   dataSource$ = this.appSelectors.dataSource$();
   filter: FormControl = new FormControl();
 
@@ -38,7 +39,7 @@ export class VillainListComponent implements OnDestroy, OnInit {
   private villainSelector: EntitySelector<Villain>;
   private filterLogic = pipe(
     takeUntil(this.onDestroy),
-    tap(value => this.filter.setValue(value)),
+    tap((value: EntityFilter) => this.filter.setValue(value.pattern)),
     debounceTime(300),
     distinctUntilChanged()
   );
@@ -74,8 +75,8 @@ export class VillainListComponent implements OnDestroy, OnInit {
     this.onDestroy.next(true);
   }
 
-  setFilter(value: string) {
-    this.villainDispatcher.setFilter(value);
+  setFilter(pattern: string) {
+    this.villainDispatcher.setFilter({ pattern });
     this.clear();
   }
 

--- a/src/client/ngrx-data/entity-data.service.ts
+++ b/src/client/ngrx-data/entity-data.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
+import { EntityAction } from './entity.actions';
+
 import {
-  EntityAction,
   EntityCache,
   EntityClass,
   EntityCollection,

--- a/src/client/ngrx-data/entity-filter.service.ts
+++ b/src/client/ngrx-data/entity-filter.service.ts
@@ -1,0 +1,108 @@
+import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
+import { EntityClass, getEntityName } from './interfaces';
+
+/** EntityAction Filter payload */
+export interface EntityFilter {
+  /** Name of the filter */
+  name?: string;
+  /** Search pattern for the filter to apply */
+  pattern?: any;
+}
+
+/**
+ * Filters the `entities` array argument and returns the `entities`,
+ * a memoized array of entities, or a new filtered array.
+ * NEVER mutate the `entities` array itself.
+ **/
+export type EntityFilterFn<T> = (entities: T[], pattern?: any) => T[];
+
+export interface EntityFilterDef<T> {
+  filterFn: EntityFilterFn<T>;
+  include?: string[]; // entity type names to include
+  exclude?: string[]; // entity type names to exclude
+}
+
+export interface EntityFilters { [name: string]: EntityFilterDef<any> }
+
+export const ENTITY_FILTERS = new InjectionToken<EntityFilters>('ENTITY_FILTERS');
+
+/** EntityFilter function: match pattern in the entity name. */
+export function GenericNameFilterFn<T>(entities: T[], pattern: string) {
+  pattern = pattern && pattern.trim();
+  if (!pattern) { return entities; }
+  const regEx = new RegExp(pattern, 'i');
+  return entities.filter((e: any) => regEx.test(e.name));
+}
+
+/** The default EntityFilter */
+export const DefaultEntityFilters: EntityFilters = {
+  '': { filterFn: GenericNameFilterFn }
+}
+
+@Injectable()
+export class EntityFilterService {
+
+  private filters: EntityFilters = { };
+
+  constructor(@Optional() @Inject(ENTITY_FILTERS) filters: EntityFilters[] = []) {
+    filters.forEach(f => this.registerFilters(f));
+  }
+
+ /**
+   * Get an {EntityFilter} by name.
+   * @param name - filter name; empty name is the default filter
+   *
+   * Examples:
+   *   getFilter('');// the default filter
+   *   getFilter('Foo'); // the filter named 'Foo'
+   *   getFilter('Hero'); // a filter for heroes only
+   */
+  getFilter<T>(name = '', entityName?: EntityClass<T> | string): EntityFilterDef<T> {
+    name = name.trim();
+    entityName = getEntityName(entityName);
+    const filter = this.filters[name];
+    if (!filter) {
+      throw new Error(`No filter named "${name}" for ${entityName} entities.`);
+    }
+    if (!entityName) { return filter; }
+    if ((filter.exclude && -1 !== filter.exclude.indexOf(entityName)) ||
+        (filter.include && -1 === filter.include.indexOf(entityName))
+      ) {
+        throw new Error(`Filter "${name}" disallowed for ${entityName} entities.`);
+    }
+    return filter;
+  }
+  getFilterFn<T>(name = '', entityName?: EntityClass<T> | string): EntityFilterFn<T> {
+    return this.getFilter<T>(name, entityName).filterFn;
+  }
+
+
+  /**
+   * Register a filter for an entity class
+   * @param entityClass - the name of the entity class or the class itself
+   * @param filter - filter for that entity class
+   *
+   * Examples:
+   *   registerFilter('', MyDefaultFilter);
+   *   registerFilter('Foo', MyFooFilter);
+   *   registerFilter('Hero', MyHeroOnlyFilter);
+   */
+  registerFilter<T>(name: string, filter: EntityFilterDef<T>) {
+    this.filters[name] = filter;
+  }
+
+  /**
+   * Register a batch of filters.
+   * @param filters - filters to merge into existing filters
+   *
+   * Examples:
+   *   registerFilters({
+   *     '': MyDefaultFilter,
+   *     Foo: MyFooFilter,
+   *     Hero: MyHeroOnlyFilter,
+   *   });
+   */
+  registerFilters(filters: EntityFilters) {
+    this.filters = { ...this.filters, ...filters };
+  }
+}

--- a/src/client/ngrx-data/entity-persist.effects.ts
+++ b/src/client/ngrx-data/entity-persist.effects.ts
@@ -7,24 +7,19 @@ import { Observable } from 'rxjs/Observable';
 import { of } from 'rxjs/observable/of';
 import { concat, concatMap, catchError, filter, map, startWith, tap } from 'rxjs/operators';
 
-import * as EntityActions from './entity.actions';
-import {
-  DataServiceError,
-  EntityAction,
-  EntityCache,
-  EntityCollectionDataService,
-  EntityOp
-} from './interfaces';
+import { EntityAction, EntityOp } from './entity.actions';
+import { DataServiceError, EntityCache, EntityCollectionDataService } from './interfaces';
+
 type eaType = EntityAction<any, any>;
 
 import { EntityDataService } from './entity-data.service';
 
 const persistOps = [
-  EntityActions.GET_ALL,
-  EntityActions.GET_BY_ID,
-  EntityActions.ADD,
-  EntityActions._DELETE,
-  EntityActions.UPDATE
+  EntityOp.GET_ALL,
+  EntityOp.GET_BY_ID,
+  EntityOp.ADD,
+  EntityOp._DELETE,
+  EntityOp.UPDATE
 ];
 
 // filter for EntityActions with a persistable EntityOp
@@ -42,10 +37,10 @@ export class EntityPersistEffects {
       return this.callDataService(action).pipe(
         map(handleSuccess(action)),
         catchError(handleError(action)),
-        startWith(new EntityAction(action, EntityActions.SET_LOADING, true)),
+        startWith(new EntityAction(action, EntityOp.SET_LOADING, true)),
         concat([
-          new EntityAction(action, EntityActions.SET_LOADING, false),
-          new EntityAction(action, EntityActions.GET_FILTERED)
+          new EntityAction(action, EntityOp.SET_LOADING, false),
+          new EntityAction(action, EntityOp.GET_FILTERED)
         ])
       );
     } catch (err) {
@@ -56,19 +51,19 @@ export class EntityPersistEffects {
   private callDataService(action: eaType) {
     const service = this.dataService.getService(action.entityName);
     switch (action.op) {
-      case EntityActions.GET_ALL: {
+      case EntityOp.GET_ALL: {
         return service.getAll(action.payload);
       }
-      case EntityActions.GET_BY_ID: {
+      case EntityOp.GET_BY_ID: {
         return service.getById(action.payload);
       }
-      case EntityActions.ADD: {
+      case EntityOp.ADD: {
         return service.add(action.payload);
       }
-      case EntityActions._DELETE: {
+      case EntityOp._DELETE: {
         return service.delete(action.payload.id);
       }
-      case EntityActions.UPDATE: {
+      case EntityOp.UPDATE: {
         return service.update(action.payload);
       }
       default: {

--- a/src/client/ngrx-data/entity-pre-persist.effects.ts
+++ b/src/client/ngrx-data/entity-pre-persist.effects.ts
@@ -6,14 +6,14 @@ import { Actions, Effect } from '@ngrx/effects';
 import { Observable } from 'rxjs/Observable';
 import { concatMap, filter, first, mergeMap, tap } from 'rxjs/operators';
 
-import * as EntityActions from './entity.actions';
-import { EntityAction, EntityCache, EntityOp } from './interfaces';
+import { EntityAction, EntityOp } from './entity.actions';
+import { EntityCache } from './interfaces';
 import { EntitySelectors } from './entity.selectors';
 
 type eaType = EntityAction<any, any>;
 
 function isDeleteOp(action: eaType) {
-  return action.op === EntityActions.DELETE || action.op === EntityActions.DELETE_BY_ID;
+  return action.op === EntityOp.DELETE || action.op === EntityOp.DELETE_BY_ID;
 }
 
 @Injectable()
@@ -26,7 +26,7 @@ export class EntityPrePersistEffects {
     const entities$ = selector.entities$();
 
     switch (action.op) {
-      case EntityActions.DELETE: {
+      case EntityOp.DELETE: {
         const entity = action.payload;
         return entities$.pipe(
           first(),
@@ -38,7 +38,7 @@ export class EntityPrePersistEffects {
         );
       }
 
-      case EntityActions.DELETE_BY_ID: {
+      case EntityOp.DELETE_BY_ID: {
         const id = action.payload;
         return entities$.pipe(
           first(),
@@ -56,8 +56,8 @@ export class EntityPrePersistEffects {
 }
 
 function createDeleteActions(action: EntityAction<any, any>, payload: any) {
-  const deleteAct = new EntityAction(action, EntityActions._DELETE, payload);
+  const deleteAct = new EntityAction(action, EntityOp._DELETE, payload);
   return payload.index < 0
     ? [deleteAct]
-    : [deleteAct, new EntityAction(action, EntityActions._DELETE_BY_INDEX, payload)];
+    : [deleteAct, new EntityAction(action, EntityOp._DELETE_BY_INDEX, payload)];
 }

--- a/src/client/ngrx-data/entity.actions.ts
+++ b/src/client/ngrx-data/entity.actions.ts
@@ -1,55 +1,58 @@
+import { Action } from '@ngrx/store';
+import { EntityClass, getEntityName } from './interfaces';
+
 // General purpose entity action types, good for any entity type
-export const GET_ALL = 'GET_ALL';
-export const GET_ALL_SUCCESS = 'GET_ALL_SUCCESS';
-export const GET_ALL_ERROR = 'GET_ALL_ERROR';
+export enum EntityOp {
+  GET_ALL = 'GET_ALL',
+  GET_ALL_SUCCESS = 'GET_ALL_SUCCESS',
+  GET_ALL_ERROR = 'GET_ALL_ERROR',
 
-export const GET_BY_ID = 'GET_BY_ID';
-export const GET_BY_ID_SUCCESS = 'GET_BY_ID_SUCCESS';
-export const GET_BY_ID_ERROR = 'GET_BY_ID_ERROR';
+  GET_BY_ID = 'GET_BY_ID',
+  GET_BY_ID_SUCCESS = 'GET_BY_ID_SUCCESS',
+  GET_BY_ID_ERROR = 'GET_BY_ID_ERROR',
 
-export const ADD = 'ADD';
-export const ADD_ERROR = 'ADD_ERROR';
-export const ADD_SUCCESS = 'ADD_SUCCESS';
+  ADD = 'ADD',
+  ADD_ERROR = 'ADD_ERROR',
+  ADD_SUCCESS = 'ADD_SUCCESS',
 
-export const UPDATE = 'UPDATE';
-export const UPDATE_SUCCESS = 'UPDATE_SUCCESS';
-export const UPDATE_ERROR = 'UPDATE_ERROR';
+  UPDATE = 'UPDATE',
+  UPDATE_SUCCESS = 'UPDATE_SUCCESS',
+  UPDATE_ERROR = 'UPDATE_ERROR',
 
-// Calculated by delete$ effect
-export const _DELETE_BY_INDEX = '_DELETE_BY_INDEX';
-export const _DELETE = '_DELETE';
-export const _DELETE_SUCCESS = '_DELETE_SUCCESS';
-export const _DELETE_ERROR = '_DELETE_ERROR';
+  // Calculated by delete$ effect
+  _DELETE_BY_INDEX = '_DELETE_BY_INDEX',
+  _DELETE = '_DELETE',
+  _DELETE_SUCCESS = '_DELETE_SUCCESS',
+  _DELETE_ERROR = '_DELETE_ERROR',
 
-export const DELETE = 'DELETE';
-export const DELETE_BY_ID = 'DELETE_BY_ID';
+  DELETE = 'DELETE',
+  DELETE_BY_ID = 'DELETE_BY_ID',
 
-export const GET_FILTERED = 'GET_FILTERED';
-export const SET_FILTER = 'SET_FILTER';
-export const SET_FILTER_PATTERN = 'SET_FILTER_PATTERN';
+  GET_FILTERED = 'GET_FILTERED',
+  SET_FILTER = 'SET_FILTER',
+  SET_FILTER_PATTERN = 'SET_FILTER_PATTERN',
 
-export const SET_LOADING = 'SET_LOADING';
+  SET_LOADING = 'SET_LOADING',
+}
 
-export type EntityOp =
-  | 'GET_ALL'
-  | 'GET_ALL_SUCCESS'
-  | 'GET_ALL_ERROR'
-  | 'GET_BY_ID'
-  | 'GET_BY_ID_ALL_SUCCESS'
-  | 'GET_BY_ID_ERROR'
-  | 'ADD'
-  | 'ADD_SUCCESS'
-  | 'ADD_ERROR'
-  | 'UPDATE'
-  | 'UPDATE_SUCCESS'
-  | 'UPDATE_ERROR'
-  | 'DELETE'
-  | 'DELETE_BY_ID'
-  | '_DELETE_BY_INDEX'
-  | '_DELETE'
-  | '_DELETE_SUCCESS'
-  | '_DELETE_ERROR'
-  | 'GET_FILTERED'
-  | 'SET_FILTER'
-  | 'SET_FILTER_PATTERN'
-  | 'SET_LOADING';
+export class EntityAction<T extends Object, P> implements Action {
+  readonly type: string;
+  readonly entityName: string;
+
+  static formatActionTypeName(op: string, entityName: string) {
+    return `${op} [${entityName}]`.toUpperCase();
+    // return `[${entityName}] ${op.toUpperCase()} `; // an alternative
+  }
+
+  constructor(
+    classOrAction: EntityClass<T> | string | EntityAction<T, any>,
+    public readonly op: EntityOp,
+    public readonly payload?: P
+  ) {
+    this.entityName =
+      classOrAction instanceof EntityAction
+        ? classOrAction.entityName
+        : getEntityName(classOrAction);
+    this.type = EntityAction.formatActionTypeName(op, this.entityName);
+  }
+}

--- a/src/client/ngrx-data/entity.actions.ts
+++ b/src/client/ngrx-data/entity.actions.ts
@@ -26,6 +26,7 @@ export const DELETE_BY_ID = 'DELETE_BY_ID';
 
 export const GET_FILTERED = 'GET_FILTERED';
 export const SET_FILTER = 'SET_FILTER';
+export const SET_FILTER_PATTERN = 'SET_FILTER_PATTERN';
 
 export const SET_LOADING = 'SET_LOADING';
 
@@ -50,4 +51,5 @@ export type EntityOp =
   | '_DELETE_ERROR'
   | 'GET_FILTERED'
   | 'SET_FILTER'
+  | 'SET_FILTER_PATTERN'
   | 'SET_LOADING';

--- a/src/client/ngrx-data/entity.dispatchers.ts
+++ b/src/client/ngrx-data/entity.dispatchers.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
 import * as EntityActions from './entity.actions';
-import { EntityAction, EntityCache, EntityClass, EntityOp, getEntityName } from './interfaces';
+import {
+  EntityAction, EntityCache, EntityClass,
+  EntityOp, EntityFilter, getEntityName } from './interfaces';
 
 @Injectable()
 export class EntityDispatchers {
@@ -90,7 +92,11 @@ export class EntityDispatcher<T> {
     this.dispatch(EntityActions.GET_FILTERED);
   }
 
-  setFilter(filter: string) {
+  setFilter(filter: EntityFilter) {
     this.dispatch(EntityActions.SET_FILTER, filter);
+  }
+
+  setFilterPattern(pattern: any) {
+    this.dispatch(EntityActions.SET_FILTER_PATTERN, pattern);
   }
 }

--- a/src/client/ngrx-data/entity.dispatchers.ts
+++ b/src/client/ngrx-data/entity.dispatchers.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
-import * as EntityActions from './entity.actions';
-import {
-  EntityAction, EntityCache, EntityClass,
-  EntityOp, EntityFilter, getEntityName } from './interfaces';
+import { EntityAction, EntityOp } from './entity.actions';
+import { EntityCache, EntityClass, getEntityName } from './interfaces';
+import { EntityFilter } from './entity-filter.service';
 
 @Injectable()
 export class EntityDispatchers {
@@ -69,34 +68,34 @@ export class EntityDispatcher<T> {
   }
 
   add(entity: T) {
-    this.dispatch(EntityActions.ADD, entity);
+    this.dispatch(EntityOp.ADD, entity);
   }
 
   delete(entity: T) {
-    this.dispatch(EntityActions.DELETE, entity);
+    this.dispatch(EntityOp.DELETE, entity);
   }
 
   getAll(options?: any) {
-    this.dispatch(EntityActions.GET_ALL, options);
+    this.dispatch(EntityOp.GET_ALL, options);
   }
 
   getById(id: any) {
-    this.dispatch(EntityActions.GET_BY_ID, id);
+    this.dispatch(EntityOp.GET_BY_ID, id);
   }
 
   update(entity: T) {
-    this.dispatch(EntityActions.UPDATE, entity);
+    this.dispatch(EntityOp.UPDATE, entity);
   }
 
   getFiltered() {
-    this.dispatch(EntityActions.GET_FILTERED);
+    this.dispatch(EntityOp.GET_FILTERED);
   }
 
   setFilter(filter: EntityFilter) {
-    this.dispatch(EntityActions.SET_FILTER, filter);
+    this.dispatch(EntityOp.SET_FILTER, filter);
   }
 
   setFilterPattern(pattern: any) {
-    this.dispatch(EntityActions.SET_FILTER_PATTERN, pattern);
+    this.dispatch(EntityOp.SET_FILTER_PATTERN, pattern);
   }
 }

--- a/src/client/ngrx-data/entity.reducer.ts
+++ b/src/client/ngrx-data/entity.reducer.ts
@@ -1,109 +1,139 @@
+import { Injectable } from '@angular/core';
 import { Action } from '@ngrx/store';
 
 import * as EntityActions from './entity.actions';
-import { EntityAction, EntityCache, EntityCollection } from './interfaces';
+import { EntityAction, EntityCache, EntityCollection, EntityFilter } from './interfaces';
+import { EntityFilterService } from './entity-filter.service';
 
-export function entityReducer(
-  state: EntityCache = {},
-  action: EntityAction<any, any>
-): EntityCache {
-  const entityName = action.entityName;
-  if (!entityName) {
-    return state; // not an EntityAction
-  }
-
-  const collection = state[entityName];
-  // TODO: consider creating a collection if none exists.
-  //       Worried now that later implementation would depend upon
-  //       missing collection metadata.
-  if (!collection) {
-    throw new Error(`No cached collection named "${entityName}")`);
-  }
-
-  // Todo: intercept and redirect if there's a custom entity reducer
-  const newCollection = entityCollectionReducer(collection, action);
-  return collection === newCollection ? state : { ...state, ...{ [entityName]: newCollection } };
+@Injectable()
+export class EntityReducer {
+  constructor(private filterService: EntityFilterService) { }
+  getReducer() { return entityReducerFactory(this.filterService); }
 }
 
-function entityCollectionReducer<T>(
-  collection: EntityCollection<T>,
-  action: EntityAction<T, any>
-): EntityCollection<T> {
-  switch (action.op) {
-    case EntityActions.ADD_SUCCESS: {
-      // pessimistic add; add entity only upon success
-      return {
-        ...collection,
-        entities: [...collection.entities, { ...action.payload }]
-      };
+export function entityReducerFactory(filterService: EntityFilterService ) {
+
+  return function entityReducer(
+    state: EntityCache = {}, action: EntityAction<any, any>
+  ): EntityCache {
+
+    const entityName = action.entityName;
+    if (!entityName) {
+      return state; // not an EntityAction
     }
 
-    case EntityActions.GET_ALL_SUCCESS: {
-      return {
-        ...collection,
-        entities: action.payload
-      };
+    const collection = state[entityName];
+    // TODO: consider creating a collection if none exists.
+    //       Worried now that later implementation would depend upon
+    //       missing collection metadata.
+    if (!collection) {
+      throw new Error(`No cached collection named "${entityName}")`);
     }
 
-    case EntityActions._DELETE_BY_INDEX: {
-      // optimistic deletion
-      const ix: number = action.payload.index;
-      return ix == null || ix < 0
-        ? collection
-        : {
-            ...collection,
-            entities: collection.entities.slice(0, ix).concat(collection.entities.slice(ix + 1))
-          };
-    }
+    // Todo: intercept and redirect if there's a custom entityCollectionReducerFactory
+    const newCollection = entityCollectionReducerFactory(filterService)(collection, action);
 
-    case EntityActions._DELETE_ERROR: {
-      // When delete-to-server fails
-      // restore deleted entity to list (if it was known to be in the list)
-      const payload = action.payload.originalAction.payload;
-      const ix: number = payload.index;
-      return ix == null || ix < 0 || !payload.entity
-        ? collection
-        : {
-            ...collection,
-            entities: collection.entities
-              .slice(0, ix)
-              .concat(payload.entity, collection.entities.slice(ix + 1))
-          };
-    }
+    return collection === newCollection ? state :
+      { ...state, ...{ [entityName]: newCollection } };
+  }
+}
 
-    case EntityActions.UPDATE_SUCCESS: {
-      // pessimistic update; update entity only upon success
-      return {
-        ...collection,
-        entities: collection.entities.map((entity: any) => {
-          return entity.id === action.payload.id
-            ? { ...entity, ...action.payload } // merge changes
-            : entity;
-        })
-      };
-    }
+export function entityCollectionReducerFactory<T>(filterService: EntityFilterService) {
 
-    case EntityActions.GET_FILTERED: {
-      let filteredEntities: T[];
-      if (collection.filter) {
-        const filter = new RegExp(collection.filter, 'i');
-        filteredEntities = collection.entities.filter((entity: any) => filter.test(entity.name));
-      } else {
-        filteredEntities = collection.entities;
+  return function entityCollectionReducer(
+    collection: EntityCollection<T>, action: EntityAction<T, any>
+  ): EntityCollection<T> {
+
+    switch (action.op) {
+      case EntityActions.ADD_SUCCESS: {
+        // pessimistic add; add entity only upon success
+        return {
+          ...collection,
+          entities: [...collection.entities, { ...action.payload }]
+        };
       }
-      return { ...collection, filteredEntities };
-    }
 
-    case EntityActions.SET_FILTER: {
-      return { ...collection, filter: action.payload };
-    }
+      case EntityActions.GET_ALL_SUCCESS: {
+        return {
+          ...collection,
+          entities: action.payload
+        };
+      }
 
-    case EntityActions.SET_LOADING: {
-      return { ...collection, loading: action.payload };
-    }
+      case EntityActions._DELETE_BY_INDEX: {
+        // optimistic deletion
+        const ix: number = action.payload.index;
+        return ix == null || ix < 0
+          ? collection
+          : {
+              ...collection,
+              entities: collection.entities.slice(0, ix).concat(collection.entities.slice(ix + 1))
+            };
+      }
 
-    default: {
-      return collection;
+      case EntityActions._DELETE_ERROR: {
+        // When delete-to-server fails
+        // restore deleted entity to list (if it was known to be in the list)
+        const payload = action.payload.originalAction.payload;
+        const ix: number = payload.index;
+        return ix == null || ix < 0 || !payload.entity
+          ? collection
+          : {
+              ...collection,
+              entities: collection.entities
+                .slice(0, ix)
+                .concat(payload.entity, collection.entities.slice(ix + 1))
+            };
+      }
+
+      case EntityActions.UPDATE_SUCCESS: {
+        // pessimistic update; update entity only upon success
+        return {
+          ...collection,
+          entities: collection.entities.map((entity: any) => {
+            return entity.id === action.payload.id
+              ? { ...entity, ...action.payload } // merge changes
+              : entity;
+          })
+        };
+      }
+
+      // Filter getting and setting is tricky because both the existing filter and
+      // incoming payload value could be either a string or an EntityFilter.
+      // The following two reducer actions accept all four possibilities.
+      // SET_FILTER upgrades the filter to an EntityFilter if the pattern is an EntityFilter.
+
+      case EntityActions.GET_FILTERED: {
+        let filteredEntities: T[];
+        const filter = collection.filter
+        if (filter) {
+          const { name = '', pattern } =
+            typeof filter === 'string' ? { pattern: filter } : filter;
+          const filterFn = filterService.getFilterFn<T>(name, action.entityName );
+          filteredEntities = filterFn(collection.entities, pattern);
+        } else {
+          filteredEntities = collection.entities;
+        }
+        return { ...collection, filteredEntities };
+      }
+
+      case EntityActions.SET_FILTER: {
+        const filter = { ...collection.filter, ...action.payload };
+        return { ...collection, filter };
+      }
+
+      case EntityActions.SET_FILTER_PATTERN: {
+        const filter = { ...collection.filter, pattern: action.payload }
+        return { ...collection, filter }
+      }
+
+      case EntityActions.SET_LOADING: {
+        return { ...collection, loading: action.payload };
+      }
+
+      default: {
+        return collection;
+      }
     }
   }
 }

--- a/src/client/ngrx-data/entity.reducer.ts
+++ b/src/client/ngrx-data/entity.reducer.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Action } from '@ngrx/store';
 
-import * as EntityActions from './entity.actions';
-import { EntityAction, EntityCache, EntityCollection, EntityFilter } from './interfaces';
-import { EntityFilterService } from './entity-filter.service';
+import { EntityAction, EntityOp  } from './entity.actions';
+import { EntityCache, EntityCollection } from './interfaces';
+import { EntityFilterService, EntityFilter} from './entity-filter.service';
 
 @Injectable()
 export class EntityReducer {
@@ -45,7 +45,7 @@ export function entityCollectionReducerFactory<T>(filterService: EntityFilterSer
   ): EntityCollection<T> {
 
     switch (action.op) {
-      case EntityActions.ADD_SUCCESS: {
+      case EntityOp.ADD_SUCCESS: {
         // pessimistic add; add entity only upon success
         return {
           ...collection,
@@ -53,14 +53,14 @@ export function entityCollectionReducerFactory<T>(filterService: EntityFilterSer
         };
       }
 
-      case EntityActions.GET_ALL_SUCCESS: {
+      case EntityOp.GET_ALL_SUCCESS: {
         return {
           ...collection,
           entities: action.payload
         };
       }
 
-      case EntityActions._DELETE_BY_INDEX: {
+      case EntityOp._DELETE_BY_INDEX: {
         // optimistic deletion
         const ix: number = action.payload.index;
         return ix == null || ix < 0
@@ -71,7 +71,7 @@ export function entityCollectionReducerFactory<T>(filterService: EntityFilterSer
             };
       }
 
-      case EntityActions._DELETE_ERROR: {
+      case EntityOp._DELETE_ERROR: {
         // When delete-to-server fails
         // restore deleted entity to list (if it was known to be in the list)
         const payload = action.payload.originalAction.payload;
@@ -86,7 +86,7 @@ export function entityCollectionReducerFactory<T>(filterService: EntityFilterSer
             };
       }
 
-      case EntityActions.UPDATE_SUCCESS: {
+      case EntityOp.UPDATE_SUCCESS: {
         // pessimistic update; update entity only upon success
         return {
           ...collection,
@@ -103,7 +103,7 @@ export function entityCollectionReducerFactory<T>(filterService: EntityFilterSer
       // The following two reducer actions accept all four possibilities.
       // SET_FILTER upgrades the filter to an EntityFilter if the pattern is an EntityFilter.
 
-      case EntityActions.GET_FILTERED: {
+      case EntityOp.GET_FILTERED: {
         let filteredEntities: T[];
         const filter = collection.filter
         if (filter) {
@@ -117,17 +117,17 @@ export function entityCollectionReducerFactory<T>(filterService: EntityFilterSer
         return { ...collection, filteredEntities };
       }
 
-      case EntityActions.SET_FILTER: {
+      case EntityOp.SET_FILTER: {
         const filter = { ...collection.filter, ...action.payload };
         return { ...collection, filter };
       }
 
-      case EntityActions.SET_FILTER_PATTERN: {
+      case EntityOp.SET_FILTER_PATTERN: {
         const filter = { ...collection.filter, pattern: action.payload }
         return { ...collection, filter }
       }
 
-      case EntityActions.SET_LOADING: {
+      case EntityOp.SET_LOADING: {
         return { ...collection, loading: action.payload };
       }
 

--- a/src/client/ngrx-data/entity.selectors.ts
+++ b/src/client/ngrx-data/entity.selectors.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@angular/core';
 import { Store, createSelector, createFeatureSelector, Selector } from '@ngrx/store';
 
 import { Observable } from 'rxjs/Observable';
+import { map } from 'rxjs/operators';
 
-import { EntityCache, EntityClass, getEntityName } from './interfaces';
+import { EntityCache, EntityClass, EntityFilter, getEntityName } from './interfaces';
 
 type SelectorFn = <K>(prop: string) => Observable<K>;
 
@@ -76,8 +77,14 @@ export class EntitySelector<T> {
     return this.selectorFn<boolean>('loading');
   }
 
-  filter$(): Observable<string> {
-    return this.selectorFn<string>('filter');
+  filter$(): Observable<EntityFilter> {
+    return this.selectorFn<EntityFilter>('filter');
+  }
+
+  filterPattern$(): Observable<any> {
+    return this.selectorFn<EntityFilter>('filter').pipe(
+      map(filter => filter.pattern)
+    );
   }
 }
 

--- a/src/client/ngrx-data/entity.selectors.ts
+++ b/src/client/ngrx-data/entity.selectors.ts
@@ -4,7 +4,8 @@ import { Store, createSelector, createFeatureSelector, Selector } from '@ngrx/st
 import { Observable } from 'rxjs/Observable';
 import { map } from 'rxjs/operators';
 
-import { EntityCache, EntityClass, EntityFilter, getEntityName } from './interfaces';
+import { EntityCache, EntityClass, getEntityName } from './interfaces';
+import { EntityFilter } from './entity-filter.service';
 
 type SelectorFn = <K>(prop: string) => Observable<K>;
 

--- a/src/client/ngrx-data/index.ts
+++ b/src/client/ngrx-data/index.ts
@@ -1,6 +1,7 @@
 export * from './entity.actions';
 export * from './entity-data.service';
 export * from './entity.dispatchers';
+export * from './entity-filter.service';
 export * from './entity.reducer';
 export * from './entity.selectors';
 export * from './interfaces';

--- a/src/client/ngrx-data/interfaces.ts
+++ b/src/client/ngrx-data/interfaces.ts
@@ -2,31 +2,10 @@ import { Action, Store } from '@ngrx/store';
 
 import { Observable } from 'rxjs/Observable';
 
-import { EntityOp } from './entity.actions';
-export { EntityOp } from './entity.actions';
-
 import { EntityFilter } from './entity-filter.service';
-export { EntityFilter } from './entity-filter.service';
 
 export class DataServiceError<T> {
-  constructor(public error: any, public requestData: T) {}
-}
-
-export class EntityAction<T extends Object, P> implements Action {
-  readonly type: string;
-  readonly entityName: string;
-
-  constructor(
-    classOrAction: EntityClass<T> | string | EntityAction<T, any>,
-    public readonly op: EntityOp,
-    public readonly payload?: P
-  ) {
-    this.entityName =
-      classOrAction instanceof EntityAction
-        ? classOrAction.entityName
-        : getEntityName(classOrAction);
-    this.type = `${this.op} [${this.entityName}]`.toUpperCase();
-  }
+  constructor(public error: any, public requestData: T) { }
 }
 
 export abstract class EntityCollectionDataService<T> {

--- a/src/client/ngrx-data/interfaces.ts
+++ b/src/client/ngrx-data/interfaces.ts
@@ -5,6 +5,9 @@ import { Observable } from 'rxjs/Observable';
 import { EntityOp } from './entity.actions';
 export { EntityOp } from './entity.actions';
 
+import { EntityFilter } from './entity-filter.service';
+export { EntityFilter } from './entity-filter.service';
+
 export class DataServiceError<T> {
   constructor(public error: any, public requestData: T) {}
 }
@@ -42,7 +45,7 @@ export interface EntityCache {
 }
 
 export class EntityCollection<T> {
-  filter = '';
+  filter: EntityFilter = {};
   entities: T[] = [];
   filteredEntities: T[] = [];
   loading = false;
@@ -53,5 +56,5 @@ export class EntityCollection<T> {
  * @param entityClass - the name of the entity class or the class itself
  */
 export function getEntityName<T>(entityClass: string | EntityClass<T>) {
-  return typeof entityClass === 'string' ? entityClass : entityClass.name;
+  return (typeof entityClass === 'string' ? entityClass : entityClass.name).trim();
 }

--- a/src/client/ngrx-data/ngrx-data.module.ts
+++ b/src/client/ngrx-data/ngrx-data.module.ts
@@ -1,9 +1,20 @@
-import { NgModule } from '@angular/core';
+import { NgModule, InjectionToken } from '@angular/core';
+import { ActionReducer } from '@ngrx/store';
 
-import { Pluralizer, Pluralizer_, PLURALIZER_NAMES } from './pluralizer';
+import { EntityCache } from './interfaces';
+import { EntityDataService, EntityDataServiceConfig } from './entity-data.service';
 import { EntityDispatchers } from './entity.dispatchers';
 import { EntitySelectors } from './entity.selectors';
-import { EntityDataService, EntityDataServiceConfig } from './entity-data.service';
+import { EntityFilterService, ENTITY_FILTERS, DefaultEntityFilters} from './entity-filter.service';
+import { EntityReducer } from './entity.reducer';
+import { Pluralizer, _Pluralizer, PLURALIZER_NAMES } from './pluralizer';
+
+export const ENTITY_REDUCER_TOKEN =
+  new InjectionToken<ActionReducer<EntityCache>>('Entity Reducer');
+
+export function getReducer(entityReducer: EntityReducer) {
+  return entityReducer.getReducer();
+}
 
 @NgModule({
   providers: [
@@ -11,8 +22,12 @@ import { EntityDataService, EntityDataServiceConfig } from './entity-data.servic
     EntityDataServiceConfig,
     EntityDispatchers,
     EntitySelectors,
+    EntityFilterService,
+    EntityReducer,
+    { provide: ENTITY_FILTERS, multi: true, useValue: DefaultEntityFilters },
+    { provide: ENTITY_REDUCER_TOKEN, deps: [EntityReducer], useFactory: getReducer},
     { provide: PLURALIZER_NAMES, useValue: {} },
-    { provide: Pluralizer, useClass: Pluralizer_ }
+    { provide: Pluralizer, useClass: _Pluralizer }
   ]
 })
 export class NgrxDataModule {}

--- a/src/client/ngrx-data/pluralizer.ts
+++ b/src/client/ngrx-data/pluralizer.ts
@@ -12,7 +12,7 @@ export const PLURALIZER_NAMES = new InjectionToken<Indexable>('PLURALIZER_NAMES'
 
 @Injectable()
 // tslint:disable-next-line:class-name
-export class Pluralizer_ {
+export class _Pluralizer {
   constructor(@Inject(PLURALIZER_NAMES) private pluralNames: Indexable) {}
 
   /**


### PR DESCRIPTION
Two commits in this PR

## Add named entity filters (first commit)

The named filters feature changes slightly (but significantly) the way that the developer uses and configures the filter.

The idea that you might have more than one filter adds slightly to the complexity.

Can set either the pattern (`SET_FILTER_PATTERN`) or the entire filter (`SET_FILTER`).

HeroList demonstrates the old, way of having just a string. It dispatches to `SET_FILTER_PATTERN` and selects `filterPattern$`. It can only use the default filter function (the one that matches on name).

VillainList demonstrates the ability to use named filter (`NameOrSayingFilter`) that behaves differently than the default (it matches on both name and saying).

VillainListComponent dispatches to `SET_FILTER` and selects with `filter$`.

New application file, `entity-filters.ts` in CORE shows how to create a custom filter (`NameOrSayingFilter`) and setup to provide it. The `entity-store.module` shows how to initialize Villains to use it and how to provide the custom filters.

I don't know if we want to keep this in the final code. But it shows how to do it for now.


Had to enable reducer with injectable service(s) which is tricky. Changes the way you setup the feature. You have to use an injection token. Created one for ngrx-data reducer.
```
StoreModule.forFeature('entityCache', ENTITY_REDUCER_TOKEN, { initialState }),
```

## EntityOp is an `enum` (second commit)

Turned `EntityAction` names from constants into an `EntityOp` enum.

The former `EntityOp` union type had to be kept manually in sync with `EntityAction` and there were all those free-floating constants flying around.

The `enum` approach consolidates them, eliminates the dual listings, provides equal or better type-safety ... and happens also to be the way ngrx/entities does it.  I can only see positives from this approach.