### PR TITLE
refactor app's FilterComponent to be independent

### DIFF
--- a/src/client/app/heroes/heroes/heroes.component.html
+++ b/src/client/app/heroes/heroes/heroes.component.html
@@ -3,7 +3,7 @@
     <button mat-raised-button color="primary" type="button" (click)="getHeroes()" matTooltip="Refresh the heroes">Refresh</button>
     <button mat-raised-button color="primary" type="button" (click)="enableAddMode()" *ngIf="!addingHero && !selectedHero" matTooltip="Add a new hero">Add</button>
   </div>
-  <app-filter [filterPattern]="filterPattern" filterPlaceholder="Filter by each hero's name" (onFilterChange)="setFilter($event)"
+  <app-filter entityType="Hero" filterPlaceholder="Filter by each hero's name"
     class="filter-panel"></app-filter>
 </div>
 <div class="content-container">

--- a/src/client/app/heroes/heroes/heroes.component.ts
+++ b/src/client/app/heroes/heroes/heroes.component.ts
@@ -28,9 +28,7 @@ export class HeroSearchComponent implements OnDestroy, OnInit {
   filteredHeroes$: Observable<Hero[]>;
   heroes$: Observable<Hero[]>;
   loading$: Observable<boolean>;
-  filter$: Observable<string>;
   dataSource$ = this.appSelectors.dataSource$();
-  filterPattern: string;
 
   private onDestroy = new Subject();
   private heroDispatcher: EntityDispatcher<Hero>;
@@ -50,13 +48,10 @@ export class HeroSearchComponent implements OnDestroy, OnInit {
     this.filteredHeroes$ = this.heroSelectors.selectFilteredEntities$;
     this.heroes$ = this.heroSelectors.selectAll$;
     this.loading$ = this.heroSelectors.selectLoading$;
-    this.filter$ = this.heroSelectors.selectFilter$;
 
     this.dataSource$
       .pipe(takeUntil(this.onDestroy), distinctUntilChanged())
       .subscribe(value => this.getHeroes());
-
-    this.filter$.pipe(takeUntil(this.onDestroy)).subscribe(value => (this.filterPattern = value));
 
     this.heroes$
       .pipe(takeUntil(this.onDestroy), skip(1))
@@ -65,11 +60,6 @@ export class HeroSearchComponent implements OnDestroy, OnInit {
 
   ngOnDestroy() {
     this.onDestroy.next();
-  }
-
-  setFilter(pattern: string) {
-    this.heroDispatcher.setFilter(pattern);
-    this.clear();
   }
 
   clear() {

--- a/src/client/app/shared/filter/filter.component.html
+++ b/src/client/app/shared/filter/filter.component.html
@@ -2,7 +2,7 @@
   <mat-form-field>
     <input matInput [formControl]="filter"[placeholder]="filterPlaceholder">
   </mat-form-field>
-  <button mat-button *ngIf="filter.value" matSuffix mat-icon-button class="clear-button" aria-label="Clear" (click)="setFilter('')"
+  <button mat-button *ngIf="filter.value" matSuffix mat-icon-button class="clear-button" aria-label="Clear" (click)="updateFilter('')"
     matTooltip="Clear filter">
     <mat-icon>close</mat-icon>
   </button>

--- a/src/client/app/villains/villains/villains.component.html
+++ b/src/client/app/villains/villains/villains.component.html
@@ -4,7 +4,7 @@
     <button mat-raised-button color="primary" type="button" (click)="enableAddMode()" *ngIf="!addingVillain && !selectedVillain"
       matTooltip="Add a new villain">Add</button>
   </div>
-  <app-filter [filterPattern]="filterPattern" filterPlaceholder="Filter by each villain's name and saying" (onFilterChange)="setFilter($event)"
+  <app-filter entityType="Villain" filterPlaceholder="Filter by each villain's name and saying"
     class="filter-panel"></app-filter>
 </div>
 <div class="content-container">

--- a/src/client/app/villains/villains/villains.component.ts
+++ b/src/client/app/villains/villains/villains.component.ts
@@ -29,9 +29,7 @@ export class VillainSearchComponent implements OnDestroy, OnInit {
   filteredVillains$: Observable<Villain[]>;
   villains$: Observable<Villain[]>;
   loading$: Observable<boolean>;
-  filter$: Observable<string>;
   dataSource$ = this.appSelectors.dataSource$();
-  filterPattern: string;
 
   private onDestroy = new Subject();
   private villainDispatcher: EntityDispatcher<Villain>;
@@ -51,15 +49,10 @@ export class VillainSearchComponent implements OnDestroy, OnInit {
     this.filteredVillains$ = this.villainSelector.selectFilteredEntities$;
     this.villains$ = this.villainSelector.selectAll$;
     this.loading$ = this.villainSelector.selectLoading$;
-    this.filter$ = this.villainSelector.selectFilter$;
 
     this.dataSource$
       .pipe(takeUntil(this.onDestroy), distinctUntilChanged())
       .subscribe((value: string) => this.getVillains());
-
-    this.filter$.pipe(takeUntil(this.onDestroy)).subscribe(value => {
-      this.filterPattern = value;
-    });
 
     this.villains$
       .pipe(takeUntil(this.onDestroy), skip(1))
@@ -68,11 +61,6 @@ export class VillainSearchComponent implements OnDestroy, OnInit {
 
   ngOnDestroy() {
     this.onDestroy.next();
-  }
-
-  setFilter(pattern: string) {
-    this.villainDispatcher.setFilter(pattern);
-    this.clear();
   }
 
   clear() {


### PR DESCRIPTION
Revised `FilterComponent` handles entity collection filtering on its own.

Parent component wires up like this:
```
  <app-filter entityType="Villain" filterPlaceholder="Filter by each villain's name and saying"
    class="filter-panel"></app-filter>
```
Parent component just watches the `filteredEntities$` observable like this:
```
    this.filteredVillains$ = this.villainSelector.selectFilteredEntities$;
```
and presents that observable with `AsyncPipe`
