### PR TITLE
Refactor entity-service and add EntityActions observables

### DIFF
--- a/src/client/app/store/entity-store.module.ts
+++ b/src/client/app/store/entity-store.module.ts
@@ -6,8 +6,8 @@ import { pluralNames, entityMetadata } from './entity-metadata';
 
 const entityDataServiceConfig: EntityDataServiceConfig = {
   api: '/api',
-  getDelay: 300,
-  saveDelay: 100
+  getDelay:  500,
+  saveDelay: 300
 };
 
 @NgModule({

--- a/src/client/app/villains/villains/villains.component.ts
+++ b/src/client/app/villains/villains/villains.component.ts
@@ -2,14 +2,14 @@ import { Component, OnInit, ChangeDetectionStrategy, OnDestroy } from '@angular/
 import { FormControl } from '@angular/forms';
 
 import { AppSelectors } from '../../store/app-config';
-import { EntityDispatcher, EntityService, EntitySelectors$ } from '../../../ngrx-data';
+import { EntityAction, EntityActions, EntityDispatcher, EntitySelectors$,
+  EntityService, OP_ERROR, OP_SUCCESS } from '../../../ngrx-data';
 
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
-import { debounceTime, distinctUntilChanged, skip, takeUntil, take, tap } from 'rxjs/operators';
+import { distinctUntilChanged, takeUntil, tap } from 'rxjs/operators';
 
 import { Villain, ToastService } from '../../core';
-import { pipe } from 'rxjs/util/pipe';
 
 @Component({
   selector: 'app-villain-search',
@@ -22,35 +22,39 @@ export class VillainSearchComponent implements OnDestroy, OnInit {
   selectedVillain: Villain = null;
 
   filteredVillains$: Observable<Villain[]>;
-  villains$: Observable<Villain[]>;
   loading$: Observable<boolean>;
   dataSource$ = this.appSelectors.dataSource$();
 
   private onDestroy = new Subject();
   private villainDispatcher: EntityDispatcher<Villain>;
   private villainSelector: EntitySelectors$<Villain>;
+  private villainAction$: EntityActions<EntityAction<Villain>>;
 
   constructor(
-    private entityService: EntityService,
+    entityService: EntityService,
     private appSelectors: AppSelectors,
     private toast: ToastService
   ) {
     this.villainDispatcher = entityService.getDispatcher(Villain);
     this.villainSelector = entityService.getSelectors$(Villain);
+    this.villainAction$ = entityService.getEntityActions$(Villain);
+
   }
 
   ngOnInit() {
     this.filteredVillains$ = this.villainSelector.selectFilteredEntities$;
-    this.villains$ = this.villainSelector.selectAll$;
     this.loading$ = this.villainSelector.selectLoading$;
 
     this.dataSource$
       .pipe(takeUntil(this.onDestroy), distinctUntilChanged())
       .subscribe((value: string) => this.getVillains());
 
-    this.villains$
-      .pipe(takeUntil(this.onDestroy), skip(1))
-      .subscribe(villains => this.toast.openSnackBar('Fetched Villains', 'GET'));
+    this.villainAction$
+      .filter(ea => ea.op.includes(OP_SUCCESS) || ea.op.includes(OP_ERROR))
+      .until<Villain>(this.onDestroy)
+      .subscribe(
+        action => this.toast.openSnackBar(`${action.entityName} action`, action.op)
+      );
   }
 
   ngOnDestroy() {

--- a/src/client/ngrx-data/entity-data.service.ts
+++ b/src/client/ngrx-data/entity-data.service.ts
@@ -27,9 +27,9 @@ export class EntityDataService {
   // TODO:  Optionally inject specialized entity data services
   // for those that aren't derived from BaseDataService.
   constructor(
+    config: EntityDataServiceConfig,
     private http: HttpClient,
-    private pluralizer: Pluralizer,
-    private config: EntityDataServiceConfig
+    private pluralizer: Pluralizer
   ) {
     config = config || {};
     this.api = config.api != null ? '/api' : config.api;

--- a/src/client/ngrx-data/entity-definition.service.ts
+++ b/src/client/ngrx-data/entity-definition.service.ts
@@ -1,18 +1,12 @@
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
 
-import { Store, createFeatureSelector, Selector } from '@ngrx/store';
+import { Store, Selector } from '@ngrx/store';
 
 import { EntityMetadata, EntityMetadataMap } from './entity-metadata';
 import { createEntityDefinition, EntityDefinition, EntityDefinitions } from './entity-definition';
-import { EntityCache, EntityClass, getEntityName } from './interfaces';
+import { EntityCache, ENTITY_CACHE_NAME, EntityClass, ENTITY_METADATA_TOKEN, getEntityName } from './interfaces';
 import { createEntityReducer, EntityCollectionReducers } from './entity.reducer';
-import {
-  createEntitySelectors$Factory,
-  EntitySelectors,
-  EntitySelectors$
-} from './entity.selectors';
-
-export const ENTITY_METADATA = new InjectionToken<EntityMetadataMap>('ENTITY_METADATA');
+import { EntitySelectors } from './entity.selectors';
 
 @Injectable()
 export class EntityDefinitionService {
@@ -21,7 +15,7 @@ export class EntityDefinitionService {
 
   constructor(
     @Optional()
-    @Inject(ENTITY_METADATA)
+    @Inject(ENTITY_METADATA_TOKEN)
     entityMetadataMaps: EntityMetadataMap[]
   ) {
     if (entityMetadataMaps) {
@@ -50,39 +44,6 @@ export class EntityDefinitionService {
       throw new Error(`No EntityDefinition for entity type "${entityName}".`);
     }
     return definition;
-  }
-
-  getAllEntityReducers() {
-    const definitions = this.definitions;
-    const reducers: EntityCollectionReducers = {};
-    Object.keys(definitions).forEach(name => (reducers[name] = definitions[name].reducer));
-    return reducers;
-  }
-
-  getAllEntitySelectors() {
-    const definitions = this.definitions;
-    const selectors: { [name: string]: EntitySelectors<any> } = {};
-    Object.keys(definitions).forEach(name => (selectors[name] = definitions[name].selectors));
-    return selectors;
-  }
-
-  getAllEntitySelectors$(store: Store<EntityCache>, cacheName = 'entityCache') {
-    const definitions = this.definitions;
-    const selectors$: { [name: string]: EntitySelectors$<any> } = {};
-    const cacheSelector = createFeatureSelector<EntityCache>(cacheName);
-    Object.keys(definitions).forEach(
-      name => (selectors$[name] = definitions[name].selectors$Factory(store, cacheSelector))
-    );
-    return selectors$;
-  }
-
-  getAllInitialStates() {
-    const definitions = this.definitions;
-    const initialStates: { [entityName: string]: any } = {};
-    Object.keys(definitions).forEach(
-      name => (initialStates[name] = definitions[name].initialState)
-    );
-    return initialStates;
   }
 
   //////// Registration methods //////////

--- a/src/client/ngrx-data/entity-definition.ts
+++ b/src/client/ngrx-data/entity-definition.ts
@@ -4,12 +4,7 @@ import { EntityFilterFn } from './entity-filters';
 import { EntityCollectionReducer, createEntityCollectionReducer } from './entity.reducer';
 import { EntityClass, getEntityName } from './interfaces';
 import { EntityMetadata } from './entity-metadata';
-import {
-  createEntitySelectors,
-  createEntitySelectors$Factory,
-  EntitySelectors,
-  EntitySelectors$Factory
-} from './entity.selectors';
+import { createEntitySelectors, EntitySelectors } from './entity.selectors';
 
 export interface EntityCollection<T> extends EntityState<T> {
   filter: string;
@@ -23,7 +18,6 @@ export interface EntityDefinition<T> {
   metadata: EntityMetadata<T>;
   reducer: EntityCollectionReducer<T>;
   selectors: EntitySelectors<T>;
-  selectors$Factory: EntitySelectors$Factory<T>;
 }
 
 export interface EntityDefinitions {
@@ -56,15 +50,12 @@ export function createEntityDefinition<T>(
 
   const selectors = createEntitySelectors<T>(entityName, metadata.filterFn);
 
-  const selectors$Factory = createEntitySelectors$Factory<T>(entityName, initialState, selectors);
-
   return {
     entityName,
     entityAdapter,
     initialState,
     metadata,
     reducer,
-    selectors,
-    selectors$Factory
+    selectors
   };
 }

--- a/src/client/ngrx-data/entity.reducer.ts
+++ b/src/client/ngrx-data/entity.reducer.ts
@@ -23,7 +23,7 @@ export function createEntityReducer(entityDefinitionService: EntityDefinitionSer
   /** Perform Actions against the entity collections in the EntityCache */
   return function entityReducer(
     state: EntityCache = {},
-    action: EntityAction<any, any>
+    action: EntityAction
   ): EntityCache {
     const entityName = action.entityName;
     if (!entityName) {

--- a/src/client/ngrx-data/entity.selectors.ts
+++ b/src/client/ngrx-data/entity.selectors.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
-import { Store, createSelector, Selector } from '@ngrx/store';
+import { Store, createFeatureSelector, createSelector, Selector } from '@ngrx/store';
 import { Dictionary } from './ngrx-entity-models';
 
 import { Observable } from 'rxjs/Observable';
 
-import { EntityCache, EntityClass, getEntityName } from './interfaces';
+import { EntityCache, ENTITY_CACHE_NAME, EntityClass, getEntityName } from './interfaces';
 import { EntityCollection } from './entity-definition';
 import { EntityFilterFn } from './entity-filters';
 
@@ -40,8 +40,15 @@ export interface EntitySelectors$<T> {
   [selector: string]: Observable<any> | Store<any>;
 }
 
-/** Creates the selector for the path from the EntityCache through the Collection */
-export function cachedCollectionSelector<T>(
+/**
+ * Creates the selector for the path from the EntityCache through the Collection
+ * @param collectionName - which is also the entity name
+ * @param cacheSelector - selects the EntityCache from the store.
+ * @param initialState - initial state of the collection,
+ * used if the collection is undefined when the selector is invoked
+ * (as happens with time-travel debugging).
+ */
+export function createCachedCollectionSelector<T>(
   collectionName: string,
   cacheSelector: Selector<Object, EntityCache>,
   initialState: {}
@@ -50,45 +57,48 @@ export function cachedCollectionSelector<T>(
   return createSelector(cacheSelector, getCollection);
 }
 
+export const defaultEntityCacheSelector = createFeatureSelector<EntityCache>(ENTITY_CACHE_NAME);
+
 /**
- * Create factory that creates Entity Collection Selector-Observables for a given EntityCache store
- */
-export function createEntitySelectors$Factory<T>(
-  collectionName: string,
+ * Creates an entity collection's selectors$ for a given EntityCache store.
+ * `selectors$` are observable selectors of the cached entity collection.
+ * @param entityName - is also the name of the collection.
+ * @param cacheSelector - an ngrx/entity Selector that selects
+ * @param initialState - initial state of the collection,
+ * used if the collection is undefined when the selector is invoked
+ * (as happens with time-travel debugging).
+ * @param selectors - selector functions for this collection.
+ * @param store - EntityCache store with the entity collections.
+ **/
+export function createEntitySelectors$<T>(
+  entityName: string,
+  cacheSelector: Selector<Object, EntityCache>,
   initialState: any,
   selectors: EntitySelectors<T>,
-) {
-  /**
-   * Create Entity Collection Selector-Observables for a given EntityCache  store
-   * @param store - EntityCache store with the entity collections
-   * @param cacheSelector - ngrx/entity Selector that selects the EntityCache in the store.
-   **/
-  return function entitySelectors$Factory(
-    store: Store<EntityCache>,
-    cacheSelector: Selector<Object, EntityCache>
-  ) {
-    const cc = cachedCollectionSelector(collectionName, cacheSelector, initialState);
-    const collection$ = store.select(cc);
-
-    const selectors$: Partial<EntitySelectors$<T>> = {};
-    // tslint:disable-next-line:forin
-    for (const selector in selectors) {
-      selectors$[selector + '$'] = collection$.select(selectors[selector]);
-    }
-    return selectors$ as EntitySelectors$<T>;
-  };
-}
-
-export type EntitySelectors$Factory<T> = (
   store: Store<EntityCache>,
-  cacheSelector: Selector<Object, EntityCache>
-) => EntitySelectors$<T>;
+) {
+  const cc = createCachedCollectionSelector(entityName, cacheSelector, initialState);
+  const collection$ = store.select(cc);
 
+  const selectors$: Partial<EntitySelectors$<T>> = {};
+
+  Object.keys(selectors).forEach(selector =>
+    selectors$[selector + '$'] = collection$.select(selectors[selector])
+  );
+  return selectors$ as EntitySelectors$<T>;
+};
+
+/**
+ * Creates the ngrx/entity selectors or selector functions for an entity collection
+ * that an {EntitySelectors$Factory} turns into selectors$.
+ * @param entityName - name of the entity for this collection
+ * @param filterFn - the collection's {EntityFilterFn}.
+ */
 export function createEntitySelectors<T>(
   entityName: string,
   filterFn?: EntityFilterFn<T>
 ): EntitySelectors<T> {
-  // Mostly copied from `state_selectors.ts`
+  // Mostly copied from `@ngrx/entity/state_selectors.ts`
   const selectKeys = (c: EntityCollection<T>) => c.ids;
   const selectEntities = (c: EntityCollection<T>) => c.entities;
 
@@ -100,7 +110,7 @@ export function createEntitySelectors<T>(
 
   const selectCount = createSelector(selectKeys, keys => keys.length);
 
-  // EntityCollection selectors (beyond EntityState selectors)
+  // EntityCollection selectors that go beyond the ngrx/entity/EntityState selectors
   const selectFilter = (c: EntityCollection<T>) => c.filter;
 
   const selectFilteredEntities = filterFn

--- a/src/client/ngrx-data/index.ts
+++ b/src/client/ngrx-data/index.ts
@@ -14,4 +14,4 @@ export * from './interfaces';
 // export * from './ngrx-entity-models'; // try not to export
 export * from './ngrx-data.module';
 
-export { Pluralizer, PLURALIZER_NAMES } from './pluralizer';
+export { Pluralizer } from './pluralizer';

--- a/src/client/ngrx-data/interfaces.ts
+++ b/src/client/ngrx-data/interfaces.ts
@@ -1,14 +1,22 @@
 import { InjectionToken } from '@angular/core';
-import { Action, Store } from '@ngrx/store';
+import { Action, Store, ActionReducer } from '@ngrx/store';
 
 import { Observable } from 'rxjs/Observable';
 import { EntityCollection } from './entity-definition';
+import { EntityMetadataMap } from './entity-metadata';
 
 export class DataServiceError<T> {
   constructor(public error: any, public requestData: T) {}
 }
 
-export const ENTITY_CACHE_NAME = new InjectionToken<string>('ENTITY_CACHE_NAME');
+export const ENTITY_CACHE_NAME = 'entityCache';
+export const ENTITY_CACHE_NAME_TOKEN = new InjectionToken<string>('ENTITY_CACHE_NAME');
+export const ENTITY_METADATA_TOKEN = new InjectionToken<EntityMetadataMap>('ENTITY_METADATA');
+export const ENTITY_REDUCER_TOKEN = new InjectionToken<ActionReducer<EntityCache>>(
+  'Entity Reducer'
+);
+export const PLURAL_NAMES_TOKEN = new InjectionToken<{ [name: string]: string; }>('PLURAL_NAMES');
+
 
 export abstract class EntityCollectionDataService<T> {
   abstract getAll(options?: any): Observable<T[]>;
@@ -31,4 +39,23 @@ export interface EntityCache {
  */
 export function getEntityName<T>(entityClass: string | EntityClass<T>) {
   return (typeof entityClass === 'string' ? entityClass : entityClass.name).trim();
+}
+
+/**
+ * Flatten first arg if it is an array
+ * Allows fn with ...rest signature to be called with an array instead of spread
+ * Example:
+ * ```
+ * // EntityActions.ofOp
+ * const persistOps = [EntityOp.QUERY_ALL, EntityOp.ADD, ...];
+ * ofOp(...persistOps) // works
+ * ofOp(persistOps) // also works
+ * ```
+ * */
+export function flattenArgs<T>(args: any[]): T[] {
+  if (Array.isArray(args[0])) {
+    const [head, ...tail] = args;
+    args = [...head, ...tail];
+  }
+  return args;
 }

--- a/src/client/ngrx-data/ngrx-data.module.ts
+++ b/src/client/ngrx-data/ngrx-data.module.ts
@@ -2,20 +2,19 @@ import { ModuleWithProviders, NgModule, InjectionToken } from '@angular/core';
 import { ActionReducer, StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 
-import { EntityCache } from './interfaces';
+import { EntityActions } from './entity.actions';
+import { EntityCache, ENTITY_CACHE_NAME, ENTITY_CACHE_NAME_TOKEN,
+  ENTITY_METADATA_TOKEN, ENTITY_REDUCER_TOKEN,
+  PLURAL_NAMES_TOKEN } from './interfaces';
 import { EntityDataService, EntityDataServiceConfig } from './entity-data.service';
-import { EntityDefinitionService, ENTITY_METADATA } from './entity-definition.service';
+import { EntityDefinitionService } from './entity-definition.service';
 import { EntityEffects } from './entity.effects';
 import { EntityMetadataMap } from './entity-metadata';
 import { EntitySelectors } from './entity.selectors';
 import { EntityService } from './entity.service';
-import { Pluralizer, _Pluralizer, PLURALIZER_NAMES } from './pluralizer';
+import { Pluralizer, _Pluralizer } from './pluralizer';
 
 export const entityEffects: any[] = [EntityEffects];
-
-export const ENTITY_REDUCER_TOKEN = new InjectionToken<ActionReducer<EntityCache>>(
-  'Entity Reducer'
-);
 
 export function getEntityReducer(service: EntityDefinitionService) {
   return service.getEntityReducer();
@@ -29,14 +28,11 @@ export interface NgrxDataModuleConfig {
 
 @NgModule({
   imports: [
-    StoreModule.forFeature('entityCache', ENTITY_REDUCER_TOKEN, {initialState:
-      {
-        // Hero: { ids: [], entities: {}, filter: '', loading: false },
-        // // Villain: { ids: [], entities: {}, filter: '', loading: false }
-      }}),
+    StoreModule.forFeature(ENTITY_CACHE_NAME, ENTITY_REDUCER_TOKEN),
     EffectsModule.forFeature(entityEffects)
   ],
   providers: [
+    EntityActions,
     EntityDataService,
     EntityDataServiceConfig,
     EntityDefinitionService,
@@ -55,9 +51,10 @@ export class NgrxDataModule {
     return {
       ngModule: NgrxDataModule,
       providers: [
+        { provide: ENTITY_CACHE_NAME_TOKEN, useValue: ENTITY_CACHE_NAME },
         { provide: EntityDataServiceConfig, useValue: config.entityDataServiceConfig },
-        { provide: ENTITY_METADATA, multi: true, useValue: config.entityMetadata },
-        { provide: PLURALIZER_NAMES, useValue: config.pluralNames }
+        { provide: ENTITY_METADATA_TOKEN, multi: true, useValue: config.entityMetadata },
+        { provide: PLURAL_NAMES_TOKEN, useValue: config.pluralNames }
       ]
     };
   }

--- a/src/client/ngrx-data/ngrx-entity-models.ts
+++ b/src/client/ngrx-data/ngrx-entity-models.ts
@@ -1,5 +1,5 @@
 /////////////////
-// Copied from @ngrx/entity/models because that lib doesn't export them
+// Copied from `@ngrx/entity/models` because that lib doesn't export them
 // and we need them here
 export type ComparerStr<T> = (a: T, b: T) => string;
 export type ComparerNum<T> = (a: T, b: T) => number;

--- a/src/client/ngrx-data/pluralizer.ts
+++ b/src/client/ngrx-data/pluralizer.ts
@@ -1,22 +1,17 @@
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
+import { PLURAL_NAMES_TOKEN } from './interfaces';
 
 export abstract class Pluralizer {
   abstract pluralize(name: string): string;
 }
-
-interface Indexable {
-  [name: string]: string;
-}
-
-export const PLURALIZER_NAMES = new InjectionToken<Indexable>('PLURALIZER_NAMES');
 
 @Injectable()
 // tslint:disable-next-line:class-name
 export class _Pluralizer {
   constructor(
     @Optional()
-    @Inject(PLURALIZER_NAMES)
-    private pluralNames: Indexable
+    @Inject(PLURAL_NAMES_TOKEN)
+    private pluralNames: { [name: string]: string; }
   ) {
     this.pluralNames = pluralNames || {};
   }


### PR DESCRIPTION
Started as simple refactor of `EntityService` to clean up some kruft. Then saw opportunity.

Adds `EntityActions` which extend ngrx/effects `Actions` observable with methods for processing `EntityAction<T>`. These include (but are not limited to):
* `ofEntityType<T>(Hero)` - filters for the `EntityAction` s  pertaining to that `Hero` class.
* `ofOp<T>(...someEntityOps)` - filters for the selected Entity operations.
* `filter<T>(predicate)` - filter actions with your predicate
* `until<T>(notifier)` - appends `takeUntil` to help with unsubscribing.
* `share<T>()` - multi-cast the source.

You could do all of this with `pipe`. But that's a PITA for the component developer. This facility hits the primary cases and requires less RxJS know-how (and less noise in the component).

See `HeroesComponent` for example of usage.