### PR TITLE
fix master to support redux tool time-traveling

### DIFF
--- a/src/client/ngrx-data/entity-definition.ts
+++ b/src/client/ngrx-data/entity-definition.ts
@@ -56,7 +56,7 @@ export function createEntityDefinition<T>(
 
   const selectors = createEntitySelectors<T>(entityName, metadata.filterFn);
 
-  const selectors$Factory = createEntitySelectors$Factory<T>(entityName, selectors);
+  const selectors$Factory = createEntitySelectors$Factory<T>(entityName, initialState, selectors);
 
   return {
     entityName,

--- a/src/client/ngrx-data/entity.reducer.ts
+++ b/src/client/ngrx-data/entity.reducer.ts
@@ -19,7 +19,6 @@ export interface EntityCollectionReducers {
 
 /** Create the reducer for the EntityCache */
 export function createEntityReducer(entityDefinitionService: EntityDefinitionService) {
-  const entityReducers: EntityCollectionReducers = {};
 
   /** Perform Actions against the entity collections in the EntityCache */
   return function entityReducer(
@@ -31,18 +30,15 @@ export function createEntityReducer(entityDefinitionService: EntityDefinitionSer
       return state; // not an EntityAction
     }
 
+    const def = entityDefinitionService.definitions[entityName];
+    if (!def) {
+      throw new Error(`The entity "${entityName}" type is not defined.`);
+    }
+    const reducer = def.reducer;
     let collection = state[entityName];
-    let reducer: EntityCollectionReducer<any>;
-    if (collection) {
-      reducer = entityReducers[entityName];
-    } else {
+    if (!collection) {
       // Collection not in cache; create it from entity defs
-      const def = entityDefinitionService.definitions[entityName];
-      if (!def) {
-        throw new Error(`The entity "${entityName}" type is not defined.`);
-      }
       state = { ...state, [entityName]: (collection = def.initialState) };
-      entityReducers[entityName] = reducer = def.reducer;
     }
 
     const newCollection = reducer(collection, action);

--- a/src/client/ngrx-data/entity.selectors.ts
+++ b/src/client/ngrx-data/entity.selectors.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Store, createSelector, createFeatureSelector, Selector } from '@ngrx/store';
+import { Store, createSelector, Selector } from '@ngrx/store';
 import { Dictionary } from './ngrx-entity-models';
 
 import { Observable } from 'rxjs/Observable';
@@ -43,12 +43,11 @@ export interface EntitySelectors$<T> {
 /** Creates the selector for the path from the EntityCache through the Collection */
 export function cachedCollectionSelector<T>(
   collectionName: string,
-  cacheSelector: Selector<Object, EntityCache>
+  cacheSelector: Selector<Object, EntityCache>,
+  initialState: {}
 ) {
-  // collection selector
-  const c = createFeatureSelector<EntityCollection<T>>(collectionName);
-  // cache -> collection selector
-  return createSelector(cacheSelector, c);
+  const getCollection = (cache: EntityCache) => cache[collectionName] || initialState;
+  return createSelector(cacheSelector, getCollection);
 }
 
 /**
@@ -56,7 +55,8 @@ export function cachedCollectionSelector<T>(
  */
 export function createEntitySelectors$Factory<T>(
   collectionName: string,
-  selectors: EntitySelectors<T>
+  initialState: any,
+  selectors: EntitySelectors<T>,
 ) {
   /**
    * Create Entity Collection Selector-Observables for a given EntityCache  store
@@ -67,7 +67,7 @@ export function createEntitySelectors$Factory<T>(
     store: Store<EntityCache>,
     cacheSelector: Selector<Object, EntityCache>
   ) {
-    const cc = cachedCollectionSelector(collectionName, cacheSelector);
+    const cc = cachedCollectionSelector(collectionName, cacheSelector, initialState);
     const collection$ = store.select(cc);
 
     const selectors$: Partial<EntitySelectors$<T>> = {};

--- a/src/client/ngrx-data/ngrx-data.module.ts
+++ b/src/client/ngrx-data/ngrx-data.module.ts
@@ -29,7 +29,11 @@ export interface NgrxDataModuleConfig {
 
 @NgModule({
   imports: [
-    StoreModule.forFeature('entityCache', ENTITY_REDUCER_TOKEN),
+    StoreModule.forFeature('entityCache', ENTITY_REDUCER_TOKEN, {initialState:
+      {
+        // Hero: { ids: [], entities: {}, filter: '', loading: false },
+        // // Villain: { ids: [], entities: {}, filter: '', loading: false }
+      }}),
     EffectsModule.forFeature(entityEffects)
   ],
   providers: [


### PR DESCRIPTION
**Merge if desired _before_ PR #91. Close and discard _after_ merging PR #91** because that PR already has this fix.

Lost ability to use the redux time-travel feature when we went to dynamic creation of collections in cache (e80e021c) because collection selectors assume collection is initialized when they are created.

And they _are_ initialized as the app progresses. But they are "de-initialized" with time travel debugging (e.g., click the redux tool's VCR "play" button) and the selector's crash because there is no collection in the cache.

This PR fixes the problem by selecting against the collection's `initialState` object if the collection is undefined when the selector is exercised.

Tangentially, removed collection reducer caching within `EntityReducer` because it adds risk without a true performance benefit.

>The only real difference is an `a.b.c` reference instead of an `a.b` reference and that's not going to hurt performance. And the positive is that we no longer risk a stale cache of collection reducers.