### PR TITLE
Refactor: consolidate dispatcher/selectors into EntityService

### DIFF
--- a/src/client/app/heroes/heroes/heroes.component.html
+++ b/src/client/app/heroes/heroes/heroes.component.html
@@ -3,7 +3,7 @@
     <button mat-raised-button color="primary" type="button" (click)="getHeroes()" matTooltip="Refresh the heroes">Refresh</button>
     <button mat-raised-button color="primary" type="button" (click)="enableAddMode()" *ngIf="!addingHero && !selectedHero" matTooltip="Add a new hero">Add</button>
   </div>
-  <app-filter entityType="Hero" filterPlaceholder="Filter by each hero's name"
+  <app-filter [entityService]="heroService" filterPlaceholder="Filter by each hero's name"
     class="filter-panel"></app-filter>
 </div>
 <div class="content-container">

--- a/src/client/app/heroes/heroes/heroes.component.ts
+++ b/src/client/app/heroes/heroes/heroes.component.ts
@@ -2,8 +2,10 @@ import { Component, OnInit, ChangeDetectionStrategy, OnDestroy } from '@angular/
 import { FormControl } from '@angular/forms';
 
 import { AppSelectors } from '../../store/app-config';
-import { EntityAction, EntityActions, EntityDispatcher, EntitySelectors$,
-  EntityService, OP_ERROR, OP_SUCCESS } from '../../../ngrx-data';
+import {
+  EntityAction, EntityActions, EntityDispatcher, EntitySelectors$,
+  EntityService, EntityServiceFactory, OP_ERROR, OP_SUCCESS
+} from '../../../ngrx-data';
 
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -19,37 +21,34 @@ import { Hero, ToastService } from '../../core';
 })
 export class HeroSearchComponent implements OnDestroy, OnInit {
   addingHero = false;
-  selectedHero: Hero = null;
+  selectedHero: Hero;
 
+  actions$: EntityActions<EntityAction<Hero>>;
+  dataSource$: Observable<string>;
   filteredHeroes$: Observable<Hero[]>;
   loading$: Observable<boolean>;
-  dataSource$ = this.appSelectors.dataSource$();
 
+  heroService: EntityService<Hero>;
   private onDestroy = new Subject();
-  private heroDispatcher: EntityDispatcher<Hero>;
-  private heroSelectors: EntitySelectors$<Hero>;
-  private heroAction$: EntityActions<EntityAction<Hero>>;
 
   constructor(
-    entityService: EntityService,
-    private appSelectors: AppSelectors,
+    entityServiceFactory: EntityServiceFactory,
+    appSelectors: AppSelectors,
     private toast: ToastService
   ) {
-    this.heroDispatcher = entityService.getDispatcher(Hero);
-    this.heroSelectors = entityService.getSelectors$(Hero);
-    this.heroAction$ = entityService.getEntityActions$(Hero);
+    this.dataSource$ = appSelectors.dataSource$();
+    this.heroService = entityServiceFactory.create<Hero>('Hero');
+    this.filteredHeroes$ = this.heroService.filteredEntities$;
+    this.loading$ = this.heroService.loading$;
   }
 
   ngOnInit() {
-    this.filteredHeroes$ = this.heroSelectors.selectFilteredEntities$;
-    this.loading$ = this.heroSelectors.selectLoading$;
-
     this.dataSource$
       .pipe(takeUntil(this.onDestroy), distinctUntilChanged())
       .subscribe(value => this.getHeroes());
 
-    this.heroAction$
-      .filter(ea => ea.op.includes(OP_SUCCESS) || ea.op.includes(OP_ERROR))
+    this.heroService.actions$
+      .filter<Hero>(ea => ea.op.includes(OP_SUCCESS) || ea.op.includes(OP_ERROR))
       .until<Hero>(this.onDestroy)
       .subscribe(
         action => this.toast.openSnackBar(`${action.entityName} action`, action.op)
@@ -67,7 +66,7 @@ export class HeroSearchComponent implements OnDestroy, OnInit {
 
   deleteHero(hero: Hero) {
     this.unselect();
-    this.heroDispatcher.delete(hero.id);
+    this.heroService.delete(hero.id);
   }
 
   enableAddMode() {
@@ -76,7 +75,7 @@ export class HeroSearchComponent implements OnDestroy, OnInit {
   }
 
   getHeroes() {
-    this.heroDispatcher.getAll();
+    this.heroService.getAll();
     this.unselect();
   }
 
@@ -86,11 +85,11 @@ export class HeroSearchComponent implements OnDestroy, OnInit {
   }
 
   update(hero: Hero) {
-    this.heroDispatcher.update(hero);
+    this.heroService.update(hero);
   }
 
   add(hero: Hero) {
-    this.heroDispatcher.add(hero);
+    this.heroService.add(hero);
   }
 
   unselect() {

--- a/src/client/app/heroes/heroes/heroes.component.ts
+++ b/src/client/app/heroes/heroes/heroes.component.ts
@@ -23,7 +23,7 @@ export class HeroSearchComponent implements OnDestroy, OnInit {
   addingHero = false;
   selectedHero: Hero;
 
-  actions$: EntityActions<EntityAction<Hero>>;
+  actions$: EntityActions<Hero>;
   dataSource$: Observable<string>;
   filteredHeroes$: Observable<Hero[]>;
   loading$: Observable<boolean>;
@@ -48,8 +48,8 @@ export class HeroSearchComponent implements OnDestroy, OnInit {
       .subscribe(value => this.getHeroes());
 
     this.heroService.actions$
-      .filter<Hero>(ea => ea.op.includes(OP_SUCCESS) || ea.op.includes(OP_ERROR))
-      .until<Hero>(this.onDestroy)
+      .filter(ea => ea.op.includes(OP_SUCCESS) || ea.op.includes(OP_ERROR))
+      .until(this.onDestroy)
       .subscribe(
         action => this.toast.openSnackBar(`${action.entityName} action`, action.op)
       );

--- a/src/client/app/shared/filter/filter.component.ts
+++ b/src/client/app/shared/filter/filter.component.ts
@@ -12,7 +12,7 @@ import { EntityService } from '../../../ngrx-data';
   styleUrls: ['./filter.component.scss']
 })
 export class FilterComponent implements OnDestroy, OnInit {
-  @Input() entityType: string;
+  @Input() entityService: EntityService<any>;
   @Input() filterPlaceholder: string;
 
   filter: FormControl = new FormControl();
@@ -20,20 +20,16 @@ export class FilterComponent implements OnDestroy, OnInit {
 
   private onDestroy = new Subject();
 
-  constructor(private entityService: EntityService) {}
-
   ngOnInit() {
     // Set the filter to the current value from store or ''
-    const ss = this.entityService.getSelectors$(this.entityType);
-    ss.selectFilter$
+    this.entityService.filter$
       .pipe(
         take(1)
         // always completes so no need to unsubscribe
       )
       .subscribe(value => this.filter.setValue(value));
 
-    const ds = this.entityService.getDispatcher(this.entityType);
-    this.updateFilter = ds.setFilter.bind(ds);
+    this.updateFilter = this.entityService.setFilter.bind(this.entityService);
     this.filter.valueChanges
       .pipe(takeUntil(this.onDestroy), debounceTime(300), distinctUntilChanged())
       .subscribe(pattern => this.updateFilter(pattern));

--- a/src/client/app/store/entity-metadata.ts
+++ b/src/client/app/store/entity-metadata.ts
@@ -23,16 +23,18 @@ export function nameAndSayingFilter<T>(entities: T[], pattern: string) {
 
 export const entityMetadata: EntityMetadataMap = {
   Hero: {
+    entityName: 'Hero', // required
     selectId, // not necessary but shows you can supply a function
     sortComparer: sortByName,
     filterFn: nameFilter
   },
   Villain: {
+    entityName: 'Villain', // required
     filterFn: nameAndSayingFilter
   }
 };
 
 export const pluralNames = {
-  // Case matters. Match the case of the class name.
+  // Case matters. Match the case of the entity name.
   Hero: 'Heroes'
 };

--- a/src/client/app/villains/villains/villains.component.html
+++ b/src/client/app/villains/villains/villains.component.html
@@ -4,7 +4,7 @@
     <button mat-raised-button color="primary" type="button" (click)="enableAddMode()" *ngIf="!addingVillain && !selectedVillain"
       matTooltip="Add a new villain">Add</button>
   </div>
-  <app-filter entityType="Villain" filterPlaceholder="Filter by each villain's name and saying"
+  <app-filter [entityService]="villainService" filterPlaceholder="Filter by each villain's name and saying"
     class="filter-panel"></app-filter>
 </div>
 <div class="content-container">

--- a/src/client/app/villains/villains/villains.component.ts
+++ b/src/client/app/villains/villains/villains.component.ts
@@ -23,7 +23,7 @@ export class VillainSearchComponent implements OnDestroy, OnInit {
   addingVillain = false;
   selectedVillain: Villain = null;
 
-  actions$: EntityActions<EntityAction<Villain>>;
+  actions$: EntityActions<Villain>;
   dataSource$: Observable<string>;
   filteredVillains$: Observable<Villain[]>;
   loading$: Observable<boolean>;
@@ -49,7 +49,7 @@ export class VillainSearchComponent implements OnDestroy, OnInit {
 
     this.villainService.actions$
       .filter(ea => ea.op.includes(OP_SUCCESS) || ea.op.includes(OP_ERROR))
-      .until<Villain>(this.onDestroy)
+      .until(this.onDestroy)
       .subscribe(
         action => this.toast.openSnackBar(`${action.entityName} action`, action.op)
       );

--- a/src/client/app/villains/villains/villains.component.ts
+++ b/src/client/app/villains/villains/villains.component.ts
@@ -2,8 +2,10 @@ import { Component, OnInit, ChangeDetectionStrategy, OnDestroy } from '@angular/
 import { FormControl } from '@angular/forms';
 
 import { AppSelectors } from '../../store/app-config';
-import { EntityAction, EntityActions, EntityDispatcher, EntitySelectors$,
-  EntityService, OP_ERROR, OP_SUCCESS } from '../../../ngrx-data';
+import {
+  EntityAction, EntityActions, EntityDispatcher, EntitySelectors$,
+  EntityService, EntityServiceFactory, OP_ERROR, OP_SUCCESS
+} from '../../../ngrx-data';
 
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -21,35 +23,31 @@ export class VillainSearchComponent implements OnDestroy, OnInit {
   addingVillain = false;
   selectedVillain: Villain = null;
 
+  actions$: EntityActions<EntityAction<Villain>>;
+  dataSource$: Observable<string>;
   filteredVillains$: Observable<Villain[]>;
   loading$: Observable<boolean>;
-  dataSource$ = this.appSelectors.dataSource$();
 
+  villainService: EntityService<Villain>;
   private onDestroy = new Subject();
-  private villainDispatcher: EntityDispatcher<Villain>;
-  private villainSelector: EntitySelectors$<Villain>;
-  private villainAction$: EntityActions<EntityAction<Villain>>;
 
   constructor(
-    entityService: EntityService,
-    private appSelectors: AppSelectors,
+    entityServiceFactory: EntityServiceFactory,
+    appSelectors: AppSelectors,
     private toast: ToastService
   ) {
-    this.villainDispatcher = entityService.getDispatcher(Villain);
-    this.villainSelector = entityService.getSelectors$(Villain);
-    this.villainAction$ = entityService.getEntityActions$(Villain);
-
+    this.dataSource$ = appSelectors.dataSource$();
+    this.villainService = entityServiceFactory.create<Villain>('Villain');
+    this.filteredVillains$ = this.villainService.filteredEntities$;
+    this.loading$ = this.villainService.loading$;
   }
 
   ngOnInit() {
-    this.filteredVillains$ = this.villainSelector.selectFilteredEntities$;
-    this.loading$ = this.villainSelector.selectLoading$;
-
     this.dataSource$
       .pipe(takeUntil(this.onDestroy), distinctUntilChanged())
       .subscribe((value: string) => this.getVillains());
 
-    this.villainAction$
+    this.villainService.actions$
       .filter(ea => ea.op.includes(OP_SUCCESS) || ea.op.includes(OP_ERROR))
       .until<Villain>(this.onDestroy)
       .subscribe(
@@ -68,7 +66,7 @@ export class VillainSearchComponent implements OnDestroy, OnInit {
 
   deleteVillain(villain: Villain) {
     this.unselect();
-    this.villainDispatcher.delete(villain.id);
+    this.villainService.delete(villain.id);
   }
 
   enableAddMode() {
@@ -77,7 +75,7 @@ export class VillainSearchComponent implements OnDestroy, OnInit {
   }
 
   getVillains() {
-    this.villainDispatcher.getAll();
+    this.villainService.getAll();
     this.unselect();
   }
 
@@ -87,11 +85,11 @@ export class VillainSearchComponent implements OnDestroy, OnInit {
   }
 
   update(villain: Villain) {
-    this.villainDispatcher.update(villain);
+    this.villainService.update(villain);
   }
 
   add(villain: Villain) {
-    this.villainDispatcher.add(villain);
+    this.villainService.add(villain);
   }
 
   unselect() {

--- a/src/client/ngrx-data/entity-data.service.ts
+++ b/src/client/ngrx-data/entity-data.service.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 
 import { EntityAction } from './entity.actions';
 
-import { EntityClass, EntityCollectionDataService, getEntityName } from './interfaces';
+import { EntityCollectionDataService } from './interfaces';
 
 @Injectable()
 export class EntityDataServiceConfig {
@@ -39,14 +39,14 @@ export class EntityDataService {
 
   /**
    * Get (or create) a data service for entity type
-   * @param entityClass - the name of the type or the class itself
+   * @param entityName - the name of the type
    *
    * Examples:
-   *   getService(Hero);   // data service for Heroes, typed as Hero
    *   getService('Hero'); // data service for Heroes, untyped
+   *   getService<Hero>('Hero'); // data service for Heroes, typed as Hero
    */
-  getService<T>(entityClass: string | EntityClass<T>): EntityCollectionDataService<T> {
-    const entityName = getEntityName(entityClass);
+  getService<T>(entityName: string): EntityCollectionDataService<T> {
+    entityName = entityName.trim();
     let service = this.services[entityName];
     if (!service) {
       const entitiesName = this.pluralizer.pluralize(entityName);
@@ -64,18 +64,18 @@ export class EntityDataService {
 
   /**
    * Register an EntityCollectionDataService for an entity type
-   * @param entityClass - the name of the entity type or the class itself
+   * @param entityName - the name of the entity type
    * @param service - data service for that entity type
    *
    * Examples:
-   *   registerService(Hero, MyHeroDataService);
+   *   registerService('Hero', MyHeroDataService);
    *   registerService('Villain', MyVillainDataService);
    */
   registerService<T>(
-    entityClass: string | EntityClass<T>,
+    entityName: string,
     service: EntityCollectionDataService<T>
   ) {
-    this.services[getEntityName(entityClass)] = service;
+    this.services[entityName.trim()] = service;
   }
 
   /**

--- a/src/client/ngrx-data/entity-definition.service.ts
+++ b/src/client/ngrx-data/entity-definition.service.ts
@@ -4,7 +4,7 @@ import { Store, Selector } from '@ngrx/store';
 
 import { EntityMetadata, EntityMetadataMap } from './entity-metadata';
 import { createEntityDefinition, EntityDefinition, EntityDefinitions } from './entity-definition';
-import { EntityCache, ENTITY_CACHE_NAME, EntityClass, ENTITY_METADATA_TOKEN, getEntityName } from './interfaces';
+import { EntityCache, ENTITY_CACHE_NAME, ENTITY_METADATA_TOKEN } from './interfaces';
 import { createEntityReducer, EntityCollectionReducers } from './entity.reducer';
 import { EntitySelectors } from './entity.selectors';
 
@@ -30,15 +30,14 @@ export class EntityDefinitionService {
 
   /**
    * Get (or create) a data service for entity type
-   * @param entityClass - the name of the type or the class itself
+   * @param entityName - the name of the type
    *
    * Examples:
    *   getDefinition('Hero'); // definition for Heroes, untyped
-   *   getDefinition(Hero);   // definition for Heroes, typed with Hero class
    *   getDefinition<Hero>(`Hero`); // definition for Heroes, typed with Hero interface
    */
-  getDefinition<T>(entityClass: string | EntityClass<T>, shouldThrow = true): EntityDefinition<T> {
-    const entityName = getEntityName(entityClass);
+  getDefinition<T>(entityName: string, shouldThrow = true): EntityDefinition<T> {
+    entityName = entityName.trim();
     const definition = this.definitions[entityName];
     if (!definition && shouldThrow) {
       throw new Error(`No EntityDefinition for entity type "${entityName}".`);
@@ -55,12 +54,11 @@ export class EntityDefinitionService {
    *
    * Examples:
    *   registerMetadata('Hero', myHeroEntityDefinition); // untyped
-   *   registerMetadata(Hero, myHeroEntityDefinition); // typed, Hero is a class
    *   registerMetadata<Hero>('Hero', myHeroEntityDefinition); // typed, Hero is an interface
    */
-  registerMetadata<T>(entityType: EntityClass<T> | string, metadata: EntityMetadata<T>) {
+  registerMetadata<T>(entityName: string, metadata: EntityMetadata<T>) {
     if (metadata) {
-      const definition = createEntityDefinition(entityType, metadata);
+      const definition = createEntityDefinition(metadata);
       this.registerDefinition(definition);
     }
   }

--- a/src/client/ngrx-data/entity-definition.ts
+++ b/src/client/ngrx-data/entity-definition.ts
@@ -2,7 +2,6 @@ import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
 
 import { EntityFilterFn } from './entity-filters';
 import { EntityCollectionReducer, createEntityCollectionReducer } from './entity.reducer';
-import { EntityClass, getEntityName } from './interfaces';
 import { EntityMetadata } from './entity-metadata';
 import { createEntitySelectors, EntitySelectors } from './entity.selectors';
 
@@ -25,16 +24,15 @@ export interface EntityDefinitions {
 }
 
 export function createEntityDefinition<T>(
-  entityClass: EntityClass<T> | string,
   metadata: EntityMetadata<T>,
   additionalCollectionState: {} = {}
 ) {
-  const entityName = getEntityName(entityClass) || metadata.entityName;
+  let entityName = metadata.entityName;
   if (!entityName) {
     throw new Error('Missing required entityName');
   }
 
-  metadata.entityName = metadata.entityName || entityName;
+  metadata.entityName = entityName = entityName.trim();
   metadata.selectId = metadata.selectId || ((entity: any) => entity.id);
 
   // extract known essential properties driving entity definition.

--- a/src/client/ngrx-data/entity-dispatcher.ts
+++ b/src/client/ngrx-data/entity-dispatcher.ts
@@ -1,16 +1,16 @@
 import { Store } from '@ngrx/store';
 
 import { EntityAction, EntityOp } from './entity.actions';
-import { EntityCache, EntityClass, getEntityName } from './interfaces';
+import { EntityCache } from './interfaces';
 
 /**
  * Dispatches Entity-related commands to effects and reducers
  */
 export class EntityDispatcher<T> {
-  constructor(private entityType: EntityClass<T> | string, private store: Store<EntityCache>) {}
+  constructor(private entityName: string, private store: Store<EntityCache>) {}
 
   private dispatch(op: EntityOp, payload?: any) {
-    this.store.dispatch(new EntityAction(this.entityType, op, payload));
+    this.store.dispatch(new EntityAction(this.entityName, op, payload));
   }
 
   /**

--- a/src/client/ngrx-data/entity-metadata.ts
+++ b/src/client/ngrx-data/entity-metadata.ts
@@ -7,7 +7,7 @@ export interface EntityMetadataMap {
 }
 
 export interface EntityMetadata<T> {
-  entityName?: string;
+  entityName: string;
   filterFn?: EntityFilterFn<T>;
   selectId?: IdSelector<T>;
   sortComparer?: false | Comparer<T>;

--- a/src/client/ngrx-data/entity.actions.ts
+++ b/src/client/ngrx-data/entity.actions.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Action } from '@ngrx/store';
 import { Actions } from '@ngrx/effects';
-import { EntityClass, flattenArgs, getEntityName } from './interfaces';
+import { flattenArgs } from './interfaces';
 
 import { Observable } from 'rxjs/Observable';
 import { Operator } from 'rxjs/Operator';
@@ -63,14 +63,14 @@ export class EntityAction<T extends Object = Object, P = any> implements Action 
   }
 
   constructor(
-    classOrAction: EntityClass<T> | string | EntityAction<T, any>,
+    nameOrAction: string | EntityAction<T, any>,
     public readonly op: EntityOp,
     public readonly payload?: P
   ) {
     this.entityName =
-      classOrAction instanceof EntityAction
-        ? classOrAction.entityName
-        : getEntityName(classOrAction);
+      (nameOrAction instanceof EntityAction
+        ? nameOrAction.entityName
+        : nameOrAction).trim();
     this.type = EntityAction.formatActionTypeName(op, this.entityName);
   }
 }
@@ -121,14 +121,13 @@ export class EntityActions<V = any> extends Observable<EntityAction<V>> {
 
   /**
    * Entity actions of the given entity type
-   * @param entityClass - the entity type name or the entity class
+   * @param entityName - the entity type name or the entity class
    * Example:
-   *  this.actions$.ofEntityType(Hero) // Hero entity, typed by Hero class
    *  this.actions$.ofEntityType('Hero') // Hero entity, untyped
    *  this.actions$.ofEntityType<Hero>('Hero') // typed by Hero interface.
    */
-  ofEntityType<T>(entityClass: EntityClass<T> | string): EntityActions<T> {
-    const entityName = getEntityName(entityClass);
+  ofEntityType<T>(entityName: string): EntityActions<T> {
+    entityName = entityName.trim();
     return this.filter<T>(ea => entityName === ea.entityName);
   }
 
@@ -195,7 +194,7 @@ export class EntityActions<V = any> extends Observable<EntityAction<V>> {
    * Uses RxJS `takeUntil().`
    * @param notifier - observable that stops the source with a `next()`.
    * Example:
-   *  this.actions$.ofEntityType(Hero).until<Hero>(this.onDestroy);
+   *  this.actions$.ofEntityType<Hero>('Hero').until<Hero>(this.onDestroy);
    */
   until<T>(notifier: Observable<any>): EntityActions<T> {
     return takeUntil<EntityAction<T>>(notifier)(this) as EntityActions<T>;

--- a/src/client/ngrx-data/entity.actions.ts
+++ b/src/client/ngrx-data/entity.actions.ts
@@ -96,7 +96,7 @@ export class EntityActions<V extends EntityAction = EntityAction> extends Observ
    * Filter actions based on a predicate.
    * @param predicate -returns true if EntityAction passes the test.
    * Example:
-   *  this.actions$.ofEntity() // actions for  Heroes, Villains, ...
+   *  this.actions$.filter<Hero>(ea => ea.op.includes(OP_SUCCESS)) // Successful hero action
    */
   filter<T>(predicate: (ea: EntityAction<T>) => boolean) {
     return filter(predicate)(this) as EntityActions<EntityAction<T>>;

--- a/src/client/ngrx-data/entity.actions.ts
+++ b/src/client/ngrx-data/entity.actions.ts
@@ -81,7 +81,7 @@ export class EntityAction<T extends Object = Object, P = any> implements Action 
  * Imitates `Actions.ofType()` in ngrx/entity.
  */
 @Injectable()
-export class EntityActions<V extends EntityAction = EntityAction> extends Observable<V> {
+export class EntityActions<V = any> extends Observable<EntityAction<V>> {
 
   // Inject the ngrx/entity Actions observable that watches dispatches to the store
   constructor(source?: Actions) {
@@ -99,7 +99,7 @@ export class EntityActions<V extends EntityAction = EntityAction> extends Observ
    *  this.actions$.filter<Hero>(ea => ea.op.includes(OP_SUCCESS)) // Successful hero action
    */
   filter<T>(predicate: (ea: EntityAction<T>) => boolean) {
-    return filter(predicate)(this) as EntityActions<EntityAction<T>>;
+    return filter(predicate)(this) as EntityActions<T>;
   }
 
   lift<R>(operator: Operator<V, R>): Observable<R> {
@@ -115,7 +115,7 @@ export class EntityActions<V extends EntityAction = EntityAction> extends Observ
    * Example:
    *  this.actions$.ofEntity() // actions for  Heroes, Villains, ...
    */
-  ofEntity<T>(): EntityActions<EntityAction<T>> {
+  ofEntity<T>(): EntityActions<T> {
     return this.filter<T>(ea => !!ea.entityName);
   }
 
@@ -127,7 +127,7 @@ export class EntityActions<V extends EntityAction = EntityAction> extends Observ
    *  this.actions$.ofEntityType('Hero') // Hero entity, untyped
    *  this.actions$.ofEntityType<Hero>('Hero') // typed by Hero interface.
    */
-  ofEntityType<T>(entityClass: EntityClass<T> | string): EntityActions<EntityAction<T>> {
+  ofEntityType<T>(entityClass: EntityClass<T> | string): EntityActions<T> {
     const entityName = getEntityName(entityClass);
     return this.filter<T>(ea => entityName === ea.entityName);
   }
@@ -142,9 +142,9 @@ export class EntityActions<V extends EntityAction = EntityAction> extends Observ
    *  this.actions$.ofEntityTypes(theChosen)
    * ```
    */
-  ofEntityTypes<T>(allowedEntityNames: string[]): EntityActions<EntityAction<T>>
-  ofEntityTypes<T>(...allowedEntityNames: string[]): EntityActions<EntityAction<T>>
-  ofEntityTypes<T>(...allowedEntityNames: any[]): EntityActions<EntityAction<T>> {
+  ofEntityTypes<T>(allowedEntityNames: string[]): EntityActions<T>
+  ofEntityTypes<T>(...allowedEntityNames: string[]): EntityActions<T>
+  ofEntityTypes<T>(...allowedEntityNames: any[]): EntityActions<T> {
     const names: string[]  = flattenArgs(allowedEntityNames);
     return this.filter<T>(ea =>
       ea.entityName && names.some(name => name === ea.entityName)
@@ -161,8 +161,8 @@ export class EntityActions<V extends EntityAction = EntityAction> extends Observ
    *  this.actions$.ofOp(queryOps)
    * ```
    */
-  ofOp(allowedOps: string[] | EntityOp[]): EntityActions<EntityAction>
-  ofOp(...allowedOps: (string | EntityOp)[]): EntityActions<EntityAction>
+  ofOp(allowedOps: string[] | EntityOp[]): EntityActions
+  ofOp(...allowedOps: (string | EntityOp)[]): EntityActions
   ofOp(...allowedOps: any[]) {
     // string is the runtime type of an EntityOp enum
     const ops: string[] = flattenArgs(allowedOps);
@@ -179,9 +179,9 @@ export class EntityActions<V extends EntityAction = EntityAction> extends Observ
    *  this.actions$.ofTypes(someTypes)
    * ```
    */
-  ofType<T>(allowedTypes: string[]): EntityActions<EntityAction<T>>
-  ofType<T>(...allowedTypes: string[]): EntityActions<EntityAction<T>>
-  ofType<T>(...allowedTypes: any[]): EntityActions<EntityAction<T>> {
+  ofType<T>(allowedTypes: string[]): EntityActions<T>
+  ofType<T>(...allowedTypes: string[]): EntityActions<T>
+  ofType<T>(...allowedTypes: any[]): EntityActions<T> {
     const types: string[] = flattenArgs(allowedTypes);
     return this.filter<T>(ea =>
       !!ea.entityName && types.some(type => type === ea.type)
@@ -197,7 +197,7 @@ export class EntityActions<V extends EntityAction = EntityAction> extends Observ
    * Example:
    *  this.actions$.ofEntityType(Hero).until<Hero>(this.onDestroy);
    */
-  until<T>(notifier: Observable<any>): EntityActions<EntityAction<T>> {
-    return takeUntil<EntityAction<T>>(notifier)(this) as EntityActions<EntityAction<T>>;
+  until<T>(notifier: Observable<any>): EntityActions<T> {
+    return takeUntil<EntityAction<T>>(notifier)(this) as EntityActions<T>;
   }
 }

--- a/src/client/ngrx-data/entity.selectors.ts
+++ b/src/client/ngrx-data/entity.selectors.ts
@@ -4,7 +4,7 @@ import { Dictionary } from './ngrx-entity-models';
 
 import { Observable } from 'rxjs/Observable';
 
-import { EntityCache, ENTITY_CACHE_NAME, EntityClass, getEntityName } from './interfaces';
+import { EntityCache, ENTITY_CACHE_NAME, entityName } from './interfaces';
 import { EntityCollection } from './entity-definition';
 import { EntityFilterFn } from './entity-filters';
 

--- a/src/client/ngrx-data/entity.service.ts
+++ b/src/client/ngrx-data/entity.service.ts
@@ -1,27 +1,88 @@
-import { Inject, Injectable, OnDestroy } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { createFeatureSelector, Selector, Store } from '@ngrx/store';
 
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
 import { filter, share, takeUntil, tap } from 'rxjs/operators';
 
 import { EntityAction, EntityActions } from './entity.actions';
+import { Dictionary } from './ngrx-entity-models';
 
-import {
-  EntityCache, ENTITY_CACHE_NAME_TOKEN, EntityClass, getEntityName } from './interfaces';
+import { EntityCache, ENTITY_CACHE_NAME_TOKEN } from './interfaces';
 import { EntityDefinitionService } from './entity-definition.service';
 import { EntityDispatcher } from './entity-dispatcher';
 import { createEntitySelectors$, EntitySelectors$ } from './entity.selectors';
 
+// tslint:disable:member-ordering
+export interface EntityService<T> {
+  /*** COMMANDS ***/
+
+  /**
+   * Add an entity to the cache.
+   * Does not save to remote storage.
+   * Ignored if the entity is already in cache.
+   */
+  add(entity: T): void;
+
+  /** Clear the cached entity collection */
+  clear(): void;
+
+  /** Remove an entity by key from the cache. Does not delete from remote storage. */
+  delete(key: string | number): void;
+
+  /**
+   * Query remote storage for all entities and
+   * completely replace the cached collection with the queried entities.
+   */
+  getAll(options?: any): void;
+
+  /**
+   * Query remote storage for the entity with this primary key
+   * and replace the cached entity with the result if found.
+   */
+  getByKey(key: any): void;
+
+  /**
+   * Update the an entity to the cache.
+   * Does not save to remote storage.
+   * Ignored if the entity's key is not found in cache.
+   * The update entity may be partial (but must have its key)
+   * in which case it patches the existing entity.
+   */
+  update(entity: Partial<T>): void;
+
+  /**
+   * Set the pattern that the collection's filter applies
+   * when using the `filteredEntities` selector.
+   */
+  setFilter(pattern: any): void;
+
+  /*** QUERIES ***/
+
+  /** Observable of actions related to this entity type. */
+  actions$: EntityActions<EntityAction<T>>;
+  /** Observable of count of entities in the cached collection. */
+  count$: Observable<number> | Store<number>;
+  /** Observable of all entities in the cached collection. */
+  entities$: Observable<T[]> | Store<T[]>;
+  /** Observable of the map of entity keys to entities */
+  entityKeyMap$: Observable<Dictionary<T>> | Store<Dictionary<T>>;
+  /** Observable of the filter pattern applied by the entity collection's filter function */
+  filter$: Observable<string> | Store<string>;
+  /** Observable of entities in the cached collection that pass the filter function */
+  filteredEntities$: Observable<T[]> | Store<T[]>;
+  /** Observable of the keys of the cached collection, in the collection's native sort order */
+  keys$: Observable<string[] | number[]> | Store<string[] | number[]>;
+  /** Boolean Observable, true when a query command that is loading the collection is in progress. */
+  loading$: Observable<boolean> | Store<boolean>;
+}
+// tslint:enable:member-ordering
+/////////////////
+
 @Injectable()
-export class EntityService implements OnDestroy {
+export class EntityServiceFactory {
 
   private cacheSelector: Selector<Object, EntityCache>;
   private selectors$Map: { [entityName: string]: EntitySelectors$<any> } = {};
-  private onDestroy = new Subject();
-
-  /** Listen to any action related to entities. */
-  allEntityActions$: EntityActions;
 
   constructor(
     @Inject(ENTITY_CACHE_NAME_TOKEN) private cacheName: string,
@@ -31,59 +92,39 @@ export class EntityService implements OnDestroy {
   ) {
     // This service applies to the cache in ngrx/store named `cacheName`
     this.cacheSelector = createFeatureSelector(this.cacheName);
-
-    /** Observe dispatching of an Entity-related action */
-    this.allEntityActions$ = this.actions$.ofEntity()
-      .until(this.onDestroy);
-
   }
 
-  /** Listen to any action related to a given entity type. */
-  getEntityActions$<T>(entityClass: EntityClass<T> | string):
-    EntityActions<EntityAction<T>> {
-    return this.actions$.ofEntityType<T>(entityClass)
-      .until<T>(this.onDestroy);
-  }
+  create<T>(entityName: string): EntityService<T> {
+    entityName = entityName.trim();
+    const dispatcher = new EntityDispatcher<T>(entityName, this.store);
+    const def = this.entityDefinitionService.getDefinition<T>(entityName);
+    const selectors$ = createEntitySelectors$<T>(
+      entityName, this.cacheSelector, def.initialState, def.selectors, this.store);
 
-  /**
-   * Get (or create) an ngrx/store dispatcher for the entity type.
-   * @param entityClass - the class or the name of the type
-   *
-   * Examples:
-   *   getDispatcher('Hero'); // dispatcher for Heroes, untyped
-   *   getDispatcher(Hero);  // dispatcher for Heroes, typed with Hero class
-   *   getDispatcher<Hero>('Hero'); // dispatcher for Heroes, typed with Hero interface
-   */
-  getDispatcher<T>(entityClass: EntityClass<T> | string): EntityDispatcher<T> {
-    const entityName = getEntityName(entityClass);
-    return new EntityDispatcher<T>(entityName, this.store);
-  }
+    // map the ngrx/entity standard selector names to preferred EntityService selector names
+    const {
+      selectAll$: entities$,
+      selectCount$: count$,
+      selectEntities$: entityKeyMap$,
+      selectFilter$: filter$,
+      selectFilteredEntities$: filteredEntities$,
+      selectKeys$: keys$,
+      selectLoading$: loading$,
+      ...rest
+    } = selectors$;
 
-  /**
-   * Get (or create) the selector$ for the entity type's cached collection.
-   * The selectors$ are the cached collection Observables that
-   * consumers (e.g., components) subscribe to.
-   * @param entityClass - the class or the name of the type
-   *
-   * Examples:
-   *   getSelectors$('Hero'); // selectors$ for Heroes, untyped
-   *   getSelectors$(Hero);  // selectors$ for Heroes, typed with Hero class
-   *   getSelectors$<Hero>('Hero'); // selectors$ for Heroes, typed with Hero interface
-   */
-  getSelectors$<T>(entityClass: EntityClass<T> | string): EntitySelectors$<T> {
-    const entityName = getEntityName(entityClass);
-    let selectors$ = this.selectors$Map[entityName];
-    if (!selectors$) {
-      // Not in this service; create selectors$ and remember them.
-      const def = this.entityDefinitionService.getDefinition(entityClass);
-      selectors$ = createEntitySelectors$(
-        entityName, this.cacheSelector, def.initialState, def.selectors, this.store);
-      this.selectors$Map[entityName] = selectors$;
-    }
-    return selectors$;
-  }
+    const selectors$Mapped = {
+      actions$: this.actions$.ofEntityType<T>(entityName),
+      count$,
+      entityKeyMap$,
+      entities$,
+      filter$,
+      filteredEntities$,
+      keys$,
+      loading$,
+      ...rest
+    };
 
-  ngOnDestroy() {
-    this.onDestroy.next();
+    return Object.assign(dispatcher, selectors$Mapped);
   }
 }

--- a/src/client/ngrx-data/entity.service.ts
+++ b/src/client/ngrx-data/entity.service.ts
@@ -59,7 +59,7 @@ export interface EntityService<T> {
   /*** QUERIES ***/
 
   /** Observable of actions related to this entity type. */
-  actions$: EntityActions<EntityAction<T>>;
+  actions$: EntityActions<T>;
   /** Observable of count of entities in the cached collection. */
   count$: Observable<number> | Store<number>;
   /** Observable of all entities in the cached collection. */

--- a/src/client/ngrx-data/interfaces.ts
+++ b/src/client/ngrx-data/interfaces.ts
@@ -26,19 +26,11 @@ export abstract class EntityCollectionDataService<T> {
   abstract update(entity: T): Observable<T>;
 }
 
-export type EntityClass<T extends Object> = new (...x: any[]) => T;
+export type entityName<T extends Object> = new (...x: any[]) => T;
 
 export interface EntityCache {
   // Must be `any` since we don't know what type of collections we will have
   [name: string]: EntityCollection<any>;
-}
-
-/**
- * Get name of the entity type (e.g. "Hero")
- * @param entityClass - the name of the entity type or the class itself
- */
-export function getEntityName<T>(entityClass: string | EntityClass<T>) {
-  return (typeof entityClass === 'string' ? entityClass : entityClass.name).trim();
 }
 
 /**

--- a/src/client/ngrx-data/ngrx-data.module.ts
+++ b/src/client/ngrx-data/ngrx-data.module.ts
@@ -11,7 +11,7 @@ import { EntityDefinitionService } from './entity-definition.service';
 import { EntityEffects } from './entity.effects';
 import { EntityMetadataMap } from './entity-metadata';
 import { EntitySelectors } from './entity.selectors';
-import { EntityService } from './entity.service';
+import { EntityServiceFactory } from './entity.service';
 import { Pluralizer, _Pluralizer } from './pluralizer';
 
 export const entityEffects: any[] = [EntityEffects];
@@ -36,7 +36,7 @@ export interface NgrxDataModuleConfig {
     EntityDataService,
     EntityDataServiceConfig,
     EntityDefinitionService,
-    EntityService,
+    EntityServiceFactory,
     {
       provide: ENTITY_REDUCER_TOKEN,
       deps: [EntityDefinitionService],


### PR DESCRIPTION
Consolidation into one service makes component coding less verbose.

The former `EntityService` is now `EntityServiceFactory`. It has a `create` method which produces an object with the `EntityService<T>` interface. This object has the dispatcher methods and the selector observables from the previous implementation (the selector observables have simpler names without the `select` prefix.

The original selectors (not the observable ones) live on in `EntityDefinition`, with their standard ngrx/entity names (including the `select` prefix). We may revisit this decision in future.

This PR also
- simplifies the type parameter of `EntityActions` to `EntityActions<T>`; no functional change
- removes the `EntityClass` parameter option from all APIs.
- deletes the `EntityClass` definition from `./interfaces.ts`.

Although the `EntityClass` option was a nice experience, it has a high risk of breaking after minification because the implementation relied on deriving the `entityName` from the constructor function's `name` property. That would be mangled after minification. Looks up would likely fail. The Web API URL, which is derived from the `entityName` would be mangled. Too much risk.
