### PR TITLE
refactor app entity toasts to ngrx-data-toast.service

### DIFF
--- a/src/client/app/core/core.module.ts
+++ b/src/client/app/core/core.module.ts
@@ -6,6 +6,7 @@ import { ToggleDataSourceComponent } from './toggle-data-source.component';
 import { ToolbarComponent } from './toolbar/toolbar.component';
 import { SharedModule } from '../shared/shared.module';
 import { ToastService } from './toast.service';
+import { NgrxDataToastService } from './ngrx-data-toast.service';
 import { throwIfAlreadyLoaded } from './module-import-check';
 
 @NgModule({
@@ -16,13 +17,14 @@ import { throwIfAlreadyLoaded } from './module-import-check';
   ],
   declarations: [ToggleDataSourceComponent, ToolbarComponent],
   exports: [ToggleDataSourceComponent, ToolbarComponent],
-  providers: [ToastService]
+  providers: [ NgrxDataToastService, ToastService]
 })
 export class CoreModule {
   constructor(
     @Optional()
     @SkipSelf()
-    parentModule: CoreModule
+    parentModule: CoreModule,
+    toastService: NgrxDataToastService
   ) {
     throwIfAlreadyLoaded(parentModule, 'CoreModule');
   }

--- a/src/client/app/core/ngrx-data-toast.service.ts
+++ b/src/client/app/core/ngrx-data-toast.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { Actions } from '@ngrx/effects';
+
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { filter, takeUntil, tap } from 'rxjs/operators';
+
+import { EntityAction } from '../../ngrx-data';
+
+import { ToastService } from './toast.service';
+
+/** Report ngrx-data success/error actions as toast messages **/
+@Injectable()
+export class NgrxDataToastService implements OnDestroy {
+
+  private onDestroy = new Subject();
+
+  constructor(actions$: Actions, toast: ToastService) {
+    actions$.pipe(
+      filter((ea: EntityAction) => ea.op && (
+        ea.op.includes(EntityAction.OP_SUCCESS) ||
+        ea.op.includes(EntityAction.OP_ERROR))
+      ),
+      takeUntil(this.onDestroy)
+    )
+    .subscribe(action => toast.openSnackBar(`${action.entityName} action`, action.op));
+  }
+
+  ngOnDestroy() {
+    this.onDestroy.next();
+  }
+}

--- a/src/client/app/store/app-config/selectors.ts
+++ b/src/client/app/store/app-config/selectors.ts
@@ -3,6 +3,7 @@ import { Store, createFeatureSelector, createSelector } from '@ngrx/store';
 
 import { App } from '../../core';
 import { AppState } from './reducer';
+import { distinctUntilChanged, tap } from 'rxjs/operators';
 
 const getAppState = createFeatureSelector<AppState>('appConfig');
 const getDataSource = createSelector(getAppState, (state: AppState) => state.session.dataSource);
@@ -12,6 +13,6 @@ export class AppSelectors {
   constructor(private store: Store<AppState>) {}
 
   dataSource$() {
-    return this.store.select(getDataSource);
+    return this.store.select(getDataSource).pipe(distinctUntilChanged());
   }
 }

--- a/src/client/app/villains/villains/villains.component.ts
+++ b/src/client/app/villains/villains/villains.component.ts
@@ -2,13 +2,13 @@ import { Component, OnInit, ChangeDetectionStrategy, OnDestroy } from '@angular/
 import { FormControl } from '@angular/forms';
 
 import { AppSelectors } from '../../store/app-config';
-import { EntityAction, EntityActions, EntityService, EntityServiceFactory } from '../../../ngrx-data';
+import { EntityService, EntityServiceFactory } from '../../../ngrx-data';
 
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
-import { distinctUntilChanged, takeUntil, tap } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 
-import { Villain, ToastService } from '../../core';
+import { Villain } from '../../core';
 
 @Component({
   selector: 'app-villain-search',
@@ -17,21 +17,18 @@ import { Villain, ToastService } from '../../core';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class VillainSearchComponent implements OnDestroy, OnInit {
+  private onDestroy = new Subject();
   addingVillain = false;
   selectedVillain: Villain = null;
+  villainService: EntityService<Villain>;
 
-  actions$: EntityActions<Villain>;
   dataSource$: Observable<string>;
   filteredVillains$: Observable<Villain[]>;
   loading$: Observable<boolean>;
 
-  villainService: EntityService<Villain>;
-  private onDestroy = new Subject();
-
   constructor(
-    entityServiceFactory: EntityServiceFactory,
     appSelectors: AppSelectors,
-    private toast: ToastService
+    entityServiceFactory: EntityServiceFactory
   ) {
     this.dataSource$ = appSelectors.dataSource$();
     this.villainService = entityServiceFactory.create<Villain>('Villain');
@@ -41,16 +38,8 @@ export class VillainSearchComponent implements OnDestroy, OnInit {
 
   ngOnInit() {
     this.dataSource$
-      .pipe(takeUntil(this.onDestroy), distinctUntilChanged())
-      .subscribe((value: string) => this.getVillains());
-
-    this.villainService.actions$
-      .filter(ea =>
-        ea.op.includes(EntityAction.OP_SUCCESS) ||
-        ea.op.includes(EntityAction.OP_ERROR)
-      )
-      .until(this.onDestroy)
-      .subscribe(action => this.toast.openSnackBar(`${action.entityName} action`, action.op));
+    .pipe(takeUntil(this.onDestroy))
+    .subscribe((value: string) => this.getVillains());
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Lift toast notification out of individual components and do it in one place, the `NgrxDataToasterService` which is provided and injected in `CoreModule`.

Clean up the two entity components accordingly