### PR TITLE
fix data service bugs; add timeout

### DIFF
--- a/src/client/app/store/entity-store.module.ts
+++ b/src/client/app/store/entity-store.module.ts
@@ -7,7 +7,8 @@ import { pluralNames, entityMetadata } from './entity-metadata';
 const entityDataServiceConfig: EntityDataServiceConfig = {
   api: '/api',
   getDelay: 500,
-  saveDelay: 300
+  saveDelay: 300,
+  timeout: 3000,
 };
 
 @NgModule({

--- a/src/client/ngrx-data/entity-data.service.ts
+++ b/src/client/ngrx-data/entity-data.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import { EntityAction } from './entity.actions';
-
 import { EntityCollectionDataService } from './interfaces';
 
 @Injectable()
@@ -10,6 +9,7 @@ export class EntityDataServiceConfig {
   api? = '/api';
   getDelay? = 0;
   saveDelay? = 0;
+  timeout? = 0;
 }
 
 import { BasicDataService } from './basic-data.service';
@@ -21,6 +21,7 @@ export class EntityDataService {
   // Fake delays to simulate network latency
   getDelay: number;
   saveDelay: number;
+  timeout: number;
 
   private services: { [name: string]: EntityCollectionDataService<any> } = {};
 
@@ -35,6 +36,7 @@ export class EntityDataService {
     this.api = config.api != null ? '/api' : config.api;
     this.getDelay = config.getDelay || 0;
     this.saveDelay = config.saveDelay || 0;
+    this.timeout = config.timeout || 0;
   }
 
   /**
@@ -55,7 +57,8 @@ export class EntityDataService {
         entityName,
         entitiesName,
         getDelay: this.getDelay,
-        saveDelay: this.saveDelay
+        saveDelay: this.saveDelay,
+        timeout: this.timeout,
       });
       this.services[entityName] = service;
     }

--- a/src/client/ngrx-data/entity-dispatcher.ts
+++ b/src/client/ngrx-data/entity-dispatcher.ts
@@ -2,21 +2,36 @@ import { Store } from '@ngrx/store';
 
 import { EntityAction, EntityOp } from './entity.actions';
 import { EntityCache } from './interfaces';
+import { IdSelector, Update } from './ngrx-entity-models';
 
 /**
  * Dispatches Entity-related commands to effects and reducers
  */
 export class EntityDispatcher<T> {
-  constructor(private entityName: string, private store: Store<EntityCache>) {}
+  constructor(
+    private entityName: string,
+    private store: Store<EntityCache>,
+    private selectId: IdSelector<T> = ((entity: any) => entity.id)
+  ) {}
 
   private dispatch(op: EntityOp, payload?: any) {
     this.store.dispatch(new EntityAction(this.entityName, op, payload));
   }
 
   /**
-   * Add an entity to the cache.
-   * Does not save to remote storage.
-   * Ignored if the entity is already in cache.
+   * Convert an entity (or partial entity) into the `Update<T>` object
+   * `id`: the primary key and
+   * `changes`: the entity (or partial entity of changes).
+   */
+  private toUpdate: (entity: Partial<T>) => Update<T> = (entity: T) => ({
+    id: this.selectId(entity) as string,
+    changes: entity
+  });
+
+  /**
+   * Save a new entity to remote storage.
+   * Does not add to cache until save succeeds.
+   * Ignored by cache-add if the entity is already in cache.
    */
   add(entity: T) {
     this.dispatch(EntityOp.SAVE_ADD, entity);
@@ -27,7 +42,11 @@ export class EntityDispatcher<T> {
     this.dispatch(EntityOp.REMOVE_ALL);
   }
 
-  /** Remove an entity by key from the cache. Does not delete from remote storage. */
+  /**
+   * Removes entity from the cache by key
+   * and deletes entity from remote storage by key.
+   * Does not restore to cache if the delete fails.
+   * */
   delete(key: string | number) {
     this.dispatch(EntityOp.SAVE_DELETE, key);
   }
@@ -36,8 +55,8 @@ export class EntityDispatcher<T> {
    * Query remote storage for all entities and
    * completely replace the cached collection with the queried entities.
    */
-  getAll(options?: any) {
-    this.dispatch(EntityOp.QUERY_ALL, options);
+  getAll() {
+    this.dispatch(EntityOp.QUERY_ALL);
   }
 
   /**
@@ -49,14 +68,17 @@ export class EntityDispatcher<T> {
   }
 
   /**
-   * Update the an entity to the cache.
-   * Does not save to remote storage.
-   * Ignored if the entity's key is not found in cache.
+   * Save the updated entity (or partial entity) to remote storage.
+   * Updates the cached entity after the save succeeds.
+   * Update in cache is ignored if the entity's key is not found in cache.
    * The update entity may be partial (but must have its key)
    * in which case it patches the existing entity.
    */
   update(entity: Partial<T>) {
-    this.dispatch(EntityOp.SAVE_UPDATE, entity);
+    // update entity might be a partial of T but must at least have its key.
+    // pass the Update<T> structure as the payload
+    const update: Update<T> = this.toUpdate(entity);
+    this.dispatch(EntityOp.SAVE_UPDATE, update);
   }
 
   /**

--- a/src/client/ngrx-data/entity.effects.ts
+++ b/src/client/ngrx-data/entity.effects.ts
@@ -39,7 +39,7 @@ export class EntityEffects {
     const service = this.dataService.getService(action.entityName);
     switch (action.op) {
       case EntityOp.QUERY_ALL: {
-        return service.getAll(action.payload);
+        return service.getAll();
       }
       case EntityOp.QUERY_BY_KEY: {
         return service.getById(action.payload);
@@ -69,6 +69,6 @@ function handleSuccess(action: EntityAction) {
 
 function handleError(action: EntityAction) {
   const errorOp = <EntityOp>(action.op + EntityAction.OP_ERROR);
-  return (error: DataServiceError<any>) =>
+  return (error: DataServiceError) =>
     of(new EntityAction(action, errorOp, { originalAction: action, error }));
 }

--- a/src/client/ngrx-data/entity.service.ts
+++ b/src/client/ngrx-data/entity.service.ts
@@ -33,7 +33,7 @@ export interface EntityService<T> {
    * Query remote storage for all entities and
    * completely replace the cached collection with the queried entities.
    */
-  getAll(options?: any): void;
+  getAll(): void;
 
   /**
    * Query remote storage for the entity with this primary key
@@ -95,8 +95,8 @@ export class EntityServiceFactory {
 
   create<T>(entityName: string): EntityService<T> {
     entityName = entityName.trim();
-    const dispatcher = new EntityDispatcher<T>(entityName, this.store);
     const def = this.entityDefinitionService.getDefinition<T>(entityName);
+    const dispatcher = new EntityDispatcher<T>(entityName, this.store, def.selectId);
     const selectors$ = createEntitySelectors$<T>(
       entityName,
       this.cacheSelector,

--- a/src/client/ngrx-data/interfaces.ts
+++ b/src/client/ngrx-data/interfaces.ts
@@ -4,9 +4,10 @@ import { Action, Store, ActionReducer } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 import { EntityCollection } from './entity-definition';
 import { EntityMetadataMap } from './entity-metadata';
+import { IdSelector, Update } from './ngrx-entity-models';
 
-export class DataServiceError<T> {
-  constructor(public error: any, public requestData: T) {}
+export class DataServiceError<T = any> {
+  constructor(public error: any, public requestData: RequestData) {}
 }
 
 export const ENTITY_CACHE_NAME = 'entityCache';
@@ -18,11 +19,11 @@ export const ENTITY_REDUCER_TOKEN = new InjectionToken<ActionReducer<EntityCache
 export const PLURAL_NAMES_TOKEN = new InjectionToken<{ [name: string]: string }>('PLURAL_NAMES');
 
 export abstract class EntityCollectionDataService<T> {
-  abstract getAll(options?: any): Observable<T[]>;
-  abstract getById(id: any): Observable<T>;
   abstract add(entity: T): Observable<T>;
-  abstract delete(id: any): Observable<T>;
-  abstract update(entity: T): Observable<T>;
+  abstract delete(id: any): Observable<null>;
+  abstract getAll(): Observable<T[]>;
+  abstract getById(id: any): Observable<T>;
+  abstract update(update: Update<T>): Observable<Update<T>>;
 }
 
 export type entityName<T extends Object> = new (...x: any[]) => T;
@@ -49,4 +50,10 @@ export function flattenArgs<T>(args: any[]): T[] {
     args = [...head, ...tail];
   }
   return args;
+}
+
+export interface RequestData {
+  method: 'DELETE' | 'GET' | 'POST' | 'PUT';
+  url: string;
+  data: any
 }


### PR DESCRIPTION
Fixed numerous bugs in the data service area  discovered while adding `timeout` to the data service including:

* comments in dispatcher said the exact opposite of what is going on
* used `entity.id` when the PK might be named something else (must use `selectId()`.
* wrong method return types
* passed arg to `getAll` that does nothing.
* now pass more useful info about the request (`RequestData`) to `handleError` for debugging.

Why did I add `timeout` in the first place? Because it hung today, trying to reach the remote and I had locked up processes everywhere.  The timeout would free to the app to keep going (and you can go back to local).

I looked into cancel for a while. Don't know how the user would call it. So that's a future.